### PR TITLE
update fastify version to 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "homepage": "https://github.com/fastify/fastify-oauth2#readme",
   "devDependencies": {
-    "fastify": "^1.5.0",
+    "fastify": "^2.0.1",
     "nock": "^9.3.2",
     "pre-commit": "^1.2.2",
     "simple-get": "^3.0.2",

--- a/test.js
+++ b/test.js
@@ -318,6 +318,6 @@ t.test('already decorated', t => {
       callbackUri: '/callback'
     })
     .ready(err => {
-      t.strictSame(err.message, 'The decorator \'githubOAuth2\' has already been added!')
+      t.strictSame(err.message, 'FST_ERR_DEC_ALREADY_PRESENT: The decorator \'githubOAuth2\' has already been added!')
     })
 })


### PR DESCRIPTION
Closes #11 

@allevo Hope is fine for you 👍
I don't know if you would like to update all the dependencies.
This was the output of `npm outdated`

```
Package        Current  Wanted  Latest  Location
fastify         1.14.3  1.14.3   2.0.1  fastify-oauth2
nock             9.6.1   9.6.1  10.0.6  fastify-oauth2
simple-oauth2    1.6.0   1.6.0   2.2.1  fastify-oauth2
snazzy           7.1.1   7.1.1   8.0.0  fastify-oauth2
standard        11.0.1  11.0.1  12.0.1  fastify-oauth2
```