### PR TITLE
fix scope array

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ const oauthPlugin = fp(function (fastify, options, next) {
     const state = generateStateFunction()
     const urlOptions = Object.assign({}, callbackUriParams, {
       redirect_uri: callbackUri,
-      scope: scope,
+      scope: scope.join(' '),
       state: state
     })
 


### PR DESCRIPTION
With this fix, the scope array option should work with Google's OAuth v2 now.
fix #21