### PR TITLE
Typescript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ E.g. For `name: 'customOauth2'`, both helpers `getAccessTokenFromAuthorizationCo
 
 ## Usage with Typescript
 
+Type definitions are provided with package. Decoration are applied during runtime and are based on auth configuration name. One solution is leverage typescript declaration merging to add typesafe namespace.
+
+In project declarations files .d.ts
+
+```ts
+import { OAuth2Namespace } from 'fastify-oauth2';
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    facebookOAuth2: OAuth2Namespace;
+    myCustomOAuth2: OAuth2Namespace;
+  }
+}
+```
+
 ## License
 
 Licensed under [MIT](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ E.g. For `name: 'customOauth2'`, the `simple-oauth2` instance will become access
 
 In this manner we are able to register multiple OAuth providers and each OAuth providers `simple-oauth2` instance will live in it's own **namespace**.
 
-E.g. 
+E.g.
 
 - `fastify.facebook.oauth2`
 - `fastify.github.oauth2`
@@ -101,26 +101,29 @@ E.g.
 - `fastify.vkontakte.oauth2`
 
 Assuming we have registered multiple OAuth providers like this:
+
 - `fastify.register(oauthPlugin, { name: 'facebook', { ... } // facebooks credentials, startRedirectPath, callbackUri etc )`
 - `fastify.register(oauthPlugin, { name: 'github', { ... } // githubs credentials, startRedirectPath, callbackUri etc )`
 - `fastify.register(oauthPlugin, { name: 'spotify', { ... } // spotifys credentials, startRedirectPath, callbackUri etc )`
 - `fastify.register(oauthPlugin, { name: 'vkontakte', { ... } // vkontaktes credentials, startRedirectPath, callbackUri etc )`
 
-
 ## Utilities
 
 This fastify plugin adds 2 utility decorators to your fastify instance using the same **namespace**:
 
-  - `getAccessTokenFromAuthorizationCodeFlow(request, callback)`: A function that uses the Authorization code flow to fetch an OAuth2 token using the data in the last request of the flow. If the callback is not passed it will return a promise. The object resulting from the callback call or the promise resolution is a *token response* object containing the following keys:
-    - `access_token`
-    - `refresh_token` (optional, only if the `offline scope` was originally requested)
-    - `token_type` (generally `'bearer'`)
-    - `expires_in` (number of seconds for the token to expire, e.g. `240000`)
-  - `getNewAccessTokenUsingRefreshToken(refreshToken, params, callback)`: A function that takes a refresh token and retrieves a new *token response* object. This is generally useful with background processing workers to re-issue a new token when the original token has expired. The `params` argument is optional and it's an object that can be used to pass in extra parameters to the refresh request (e.g. a stricter set of scopes). If the callback is not passed this function will return a promise. The object resulting from the callback call or the promise resolution is a new *token response* object (see fields above).
+- `getAccessTokenFromAuthorizationCodeFlow(request, callback)`: A function that uses the Authorization code flow to fetch an OAuth2 token using the data in the last request of the flow. If the callback is not passed it will return a promise. The object resulting from the callback call or the promise resolution is a *token response* object containing the following keys:
+  - `access_token`
+  - `refresh_token` (optional, only if the `offline scope` was originally requested)
+  - `token_type` (generally `'bearer'`)
+  - `expires_in` (number of seconds for the token to expire, e.g. `240000`)
+- `getNewAccessTokenUsingRefreshToken(refreshToken, params, callback)`: A function that takes a refresh token and retrieves a new *token response* object. This is generally useful with background processing workers to re-issue a new token when the original token has expired. The `params` argument is optional and it's an object that can be used to pass in extra parameters to the refresh request (e.g. a stricter set of scopes). If the callback is not passed this function will return a promise. The object resulting from the callback call or the promise resolution is a new *token response* object (see fields above).
 
 E.g. For `name: 'customOauth2'`, both helpers `getAccessTokenFromAuthorizationCodeFlow` and `getNewAccessTokenUsingRefreshToken` will become accessible like this:
- - `fastify.customOauth2.getAccessTokenFromAuthorizationCodeFlow`
- - `fastify.customOauth2.getNewAccessTokenUsingRefreshToken`
+
+- `fastify.customOauth2.getAccessTokenFromAuthorizationCodeFlow`
+- `fastify.customOauth2.getNewAccessTokenUsingRefreshToken`
+
+## Usage with Typescript
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ E.g. For `name: 'customOauth2'`, both helpers `getAccessTokenFromAuthorizationCo
 
 ## Usage with Typescript
 
-Type definitions are provided with package. Decoration are applied during runtime and are based on auth configuration name. One solution is leverage typescript declaration merging to add typesafe namespace.
+Type definitions are provided with package. Decoration are applied during runtime and are based on auth configuration name. One solution is leverage typescript declaration merging to add type-safe namespace.
 
 In project declarations files .d.ts
 

--- a/examples/facebook.js
+++ b/examples/facebook.js
@@ -26,7 +26,7 @@ fastify.get('/login/facebook/callback', function (request, reply) {
     }
 
     sget.concat({
-      url: 'https://graph.facebook.com/v3.0/me',
+      url: 'https://graph.facebook.com/v6.0/me',
       method: 'GET',
       headers: {
         Authorization: 'Bearer ' + result.access_token

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,80 @@
+import * as fastify from 'fastify';
+import * as http from 'http';
+
+
+export interface OAuth2Token{
+  token_type: 'bearer';
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number
+}
+
+export interface OAuth2Namespace{
+  getAccessTokenFromAuthorizationCodeFlow(
+    request: fastify.FastifyRequest<http.IncomingMessage>, 
+  ): Promise<OAuth2Token>
+
+  getAccessTokenFromAuthorizationCodeFlow(
+    request: fastify.FastifyRequest<http.IncomingMessage>, 
+    callback: (token: OAuth2Token) => void
+  ): void
+
+  getNewAccessTokenUsingRefreshToken(
+    refreshToken: string, 
+    params: Object, 
+    callback: (token: OAuth2Token) => void
+  ): void
+
+  getNewAccessTokenUsingRefreshToken(
+    refreshToken: string, 
+    params: Object, 
+  ): Promise<OAuth2Token>
+}
+
+export interface ProviderConfiguration {
+  authorizeHost: string;
+  authorizePath: string;
+  tokenHost: string;
+  tokenPath: string;
+}
+
+export interface Credentials {
+  client: {
+    id: string;
+    secret: string;
+  };
+  auth: ProviderConfiguration;
+}
+
+export interface FastifyOAuth2Options {
+  name: string;
+  scope: string[];
+  credentials: Credentials;
+  callbackUri: string;
+  callbackUriParams?: Object;
+  generateStateFunction?: Function;
+  checkStateFunction?: Function;
+  startRedirectPath: string;
+}
+
+
+declare function fastifyOauth2(
+  instance: fastify.FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>,
+  options: FastifyOAuth2Options,
+  callback: (err?: fastify.FastifyError) => void
+): void;
+
+
+declare namespace fastifyOauth2 {
+  const FACEBOOK_CONFIGURATION: ProviderConfiguration;
+  const GITHUB_CONFIGURATION: ProviderConfiguration;
+  const LINKEDIN_CONFIGURATION: ProviderConfiguration;
+  const GOOGLE_CONFIGURATION: ProviderConfiguration;
+  const MICROSOFT_CONFIGURATION: ProviderConfiguration;
+  const SPOTIFY_CONFIGURATION: ProviderConfiguration;
+  const VKONTAKTE_CONFIGURATION: ProviderConfiguration;
+}
+
+export default fastifyOauth2;
+
+

--- a/index.js
+++ b/index.js
@@ -129,9 +129,9 @@ const oauthPlugin = fp(function (fastify, options, next) {
 
 oauthPlugin.FACEBOOK_CONFIGURATION = {
   authorizeHost: 'https://facebook.com',
-  authorizePath: '/v3.0/dialog/oauth',
+  authorizePath: '/v6.0/dialog/oauth',
   tokenHost: 'https://graph.facebook.com',
-  tokenPath: '/v3.0/oauth/access_token'
+  tokenPath: '/v6.0/oauth/access_token'
 }
 
 oauthPlugin.GITHUB_CONFIGURATION = {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   "homepage": "https://github.com/fastify/fastify-oauth2#readme",
   "devDependencies": {
     "fastify": "^2.0.1",
-    "nock": "^12.0.3",
+    "nock": "^9.0.0",
     "pre-commit": "^1.2.2",
     "simple-get": "^3.0.2",
     "snazzy": "^8.0.0",
     "standard": "^14.3.3",
-    "tap": "^14.10.6"
+    "tap": "^12.0.0"
   },
   "dependencies": {
     "es6-promisify": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   "homepage": "https://github.com/fastify/fastify-oauth2#readme",
   "devDependencies": {
     "fastify": "^2.0.1",
-    "nock": "^9.3.2",
+    "nock": "^12.0.3",
     "pre-commit": "^1.2.2",
     "simple-get": "^3.0.2",
-    "snazzy": "^7.1.1",
-    "standard": "^11.0.1",
-    "tap": "^12.0.1"
+    "snazzy": "^8.0.0",
+    "standard": "^14.3.3",
+    "tap": "^14.10.6"
   },
   "dependencies": {
     "es6-promisify": "^6.0.0",


### PR DESCRIPTION
Provide typescript support. Based on https://github.com/fastify/fastify-oauth2/pull/35.
resolves #14

Facebook Graph API version upgraded from 3 to 6.  I tested and review changelog
https://developers.facebook.com/docs/graph-api/changelog/version6.0

Additionally, I upgraded dev dependencies. 



