### PR TITLE
Fix #42

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,69 +1,11 @@
 import * as fastify from 'fastify';
 import * as http from 'http';
 
-
-export interface OAuth2Token{
-  token_type: 'bearer';
-  access_token: string;
-  refresh_token?: string;
-  expires_in: number
-}
-
-export interface OAuth2Namespace{
-  getAccessTokenFromAuthorizationCodeFlow(
-    request: fastify.FastifyRequest<http.IncomingMessage>, 
-  ): Promise<OAuth2Token>
-
-  getAccessTokenFromAuthorizationCodeFlow(
-    request: fastify.FastifyRequest<http.IncomingMessage>, 
-    callback: (token: OAuth2Token) => void
-  ): void
-
-  getNewAccessTokenUsingRefreshToken(
-    refreshToken: string, 
-    params: Object, 
-    callback: (token: OAuth2Token) => void
-  ): void
-
-  getNewAccessTokenUsingRefreshToken(
-    refreshToken: string, 
-    params: Object, 
-  ): Promise<OAuth2Token>
-}
-
-export interface ProviderConfiguration {
-  authorizeHost: string;
-  authorizePath: string;
-  tokenHost: string;
-  tokenPath: string;
-}
-
-export interface Credentials {
-  client: {
-    id: string;
-    secret: string;
-  };
-  auth: ProviderConfiguration;
-}
-
-export interface FastifyOAuth2Options {
-  name: string;
-  scope: string[];
-  credentials: Credentials;
-  callbackUri: string;
-  callbackUriParams?: Object;
-  generateStateFunction?: Function;
-  checkStateFunction?: Function;
-  startRedirectPath: string;
-}
-
-
 declare function fastifyOauth2(
   instance: fastify.FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>,
-  options: FastifyOAuth2Options,
+  options: fastifyOauth2.FastifyOAuth2Options,
   callback: (err?: fastify.FastifyError) => void
 ): void;
-
 
 declare namespace fastifyOauth2 {
   const FACEBOOK_CONFIGURATION: ProviderConfiguration;
@@ -73,8 +15,61 @@ declare namespace fastifyOauth2 {
   const MICROSOFT_CONFIGURATION: ProviderConfiguration;
   const SPOTIFY_CONFIGURATION: ProviderConfiguration;
   const VKONTAKTE_CONFIGURATION: ProviderConfiguration;
+
+  interface OAuth2Token{
+    token_type: 'bearer';
+    access_token: string;
+    refresh_token?: string;
+    expires_in: number
+  }
+
+  interface OAuth2Namespace{
+    getAccessTokenFromAuthorizationCodeFlow(
+      request: fastify.FastifyRequest<http.IncomingMessage>,
+    ): Promise<OAuth2Token>
+
+    getAccessTokenFromAuthorizationCodeFlow(
+      request: fastify.FastifyRequest<http.IncomingMessage>,
+      callback: (token: OAuth2Token) => void
+    ): void
+
+    getNewAccessTokenUsingRefreshToken(
+      refreshToken: string,
+      params: Object,
+      callback: (token: OAuth2Token) => void
+    ): void
+
+    getNewAccessTokenUsingRefreshToken(
+      refreshToken: string,
+      params: Object,
+    ): Promise<OAuth2Token>
+  }
+
+  interface ProviderConfiguration {
+    authorizeHost: string;
+    authorizePath: string;
+    tokenHost: string;
+    tokenPath: string;
+  }
+
+  interface Credentials {
+    client: {
+      id: string;
+      secret: string;
+    };
+    auth: ProviderConfiguration;
+  }
+
+  interface FastifyOAuth2Options {
+    name: string;
+    scope: string[];
+    credentials: Credentials;
+    callbackUri: string;
+    callbackUriParams?: Object;
+    generateStateFunction?: Function;
+    checkStateFunction?: Function;
+    startRedirectPath: string;
+  }
 }
 
-export default fastifyOauth2;
-
-
+export = fastifyOauth2;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ import * as http from 'http';
 declare function fastifyOauth2(
   instance: fastify.FastifyInstance<http.Server, http.IncomingMessage, http.ServerResponse>,
   options: fastifyOauth2.FastifyOAuth2Options,
-  callback: (err?: fastify.FastifyError) => void
+  callback: (err?: fastify.FastifyError) => void,
 ): void;
 
 declare namespace fastifyOauth2 {
@@ -16,33 +16,30 @@ declare namespace fastifyOauth2 {
   const SPOTIFY_CONFIGURATION: ProviderConfiguration;
   const VKONTAKTE_CONFIGURATION: ProviderConfiguration;
 
-  interface OAuth2Token{
+  interface OAuth2Token {
     token_type: 'bearer';
     access_token: string;
     refresh_token?: string;
-    expires_in: number
+    expires_in: number;
   }
 
-  interface OAuth2Namespace{
+  interface OAuth2Namespace {
     getAccessTokenFromAuthorizationCodeFlow(
       request: fastify.FastifyRequest<http.IncomingMessage>,
-    ): Promise<OAuth2Token>
+    ): Promise<OAuth2Token>;
 
     getAccessTokenFromAuthorizationCodeFlow(
       request: fastify.FastifyRequest<http.IncomingMessage>,
-      callback: (token: OAuth2Token) => void
-    ): void
+      callback: (token: OAuth2Token) => void,
+    ): void;
 
     getNewAccessTokenUsingRefreshToken(
       refreshToken: string,
       params: Object,
-      callback: (token: OAuth2Token) => void
-    ): void
+      callback: (token: OAuth2Token) => void,
+    ): void;
 
-    getNewAccessTokenUsingRefreshToken(
-      refreshToken: string,
-      params: Object,
-    ): Promise<OAuth2Token>
+    getNewAccessTokenUsingRefreshToken(refreshToken: string, params: Object): Promise<OAuth2Token>;
   }
 
   interface ProviderConfiguration {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -42,11 +42,10 @@ declare module 'fastify' {
 expectType<fastifyOauth2.ProviderConfiguration>(auth);
 expectType<string[]>(scope);
 expectType<fastifyOauth2.Credentials>(credentials);
-expectType<fastifyOauth2.Credentials>(credentials);
 
 expectType<void>(fastifyOauth2(server, OAuth2Options, () => {}));
 expectError(fastifyOauth2()); // error because missing required arguments
-expectError(fastifyOauth2(server, {}, () => {})); // error because missing required plugin options
+expectError(fastifyOauth2(server, {}, () => {})); // error because missing required options
 
 expectAssignable<fastifyOauth2.ProviderConfiguration>(fastifyOauth2.FACEBOOK_CONFIGURATION);
 expectAssignable<fastifyOauth2.ProviderConfiguration>(fastifyOauth2.GITHUB_CONFIGURATION);
@@ -59,8 +58,8 @@ expectAssignable<fastifyOauth2.ProviderConfiguration>(fastifyOauth2.VKONTAKTE_CO
 server.get('/testOauth/callback', async request => {
   expectType<fastifyOauth2.OAuth2Namespace>(server.testOAuthName);
 
-  const token = await server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request);
-  expectType<fastifyOauth2.OAuth2Token>(token);
+  expectType<fastifyOauth2.OAuth2Token>(await server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request));
+  expectType<Promise<fastifyOauth2.OAuth2Token>>(server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request));
   expectType<void>(
     server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request, (t: fastifyOauth2.OAuth2Token): void => {}),
   );
@@ -71,9 +70,13 @@ server.get('/testOauth/callback', async request => {
   ); // error because non-Promise function call should return void and have a callback argument
   expectError<void>(server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request)); // error because function call does not pass a callback as second argument.
 
+  const token = await server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request);
   if (token.refresh_token) {
     expectType<fastifyOauth2.OAuth2Token>(
       await server.testOAuthName.getNewAccessTokenUsingRefreshToken(token.refresh_token, {}),
+    );
+    expectType<Promise<fastifyOauth2.OAuth2Token>>(
+      server.testOAuthName.getNewAccessTokenUsingRefreshToken(token.refresh_token, {}),
     );
     expectType<void>(
       server.testOAuthName.getNewAccessTokenUsingRefreshToken(

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,100 @@
+import * as fastify from 'fastify';
+import * as fastifyOauth2 from '.';
+import { expectType, expectError, expectAssignable } from 'tsd';
+
+/**
+ * Preparing some data for testing.
+ */
+const auth = fastifyOauth2.GOOGLE_CONFIGURATION;
+const scope = ['r_emailaddress', 'r_basicprofile'];
+const credentials = {
+  client: {
+    id: 'test_id',
+    secret: 'test_secret',
+  },
+  auth: auth,
+};
+const OAuth2Options = {
+  name: 'testOAuthName',
+  scope: scope,
+  credentials: credentials,
+  callbackUri: 'http://localhost/testOauth/callback',
+  callbackUriParams: {},
+  generateStateFunction: () => {},
+  checkStateFunction: () => {},
+  startRedirectPath: '/login/testOauth',
+};
+
+const server = fastify();
+
+server.register(fastifyOauth2, OAuth2Options);
+
+declare module 'fastify' {
+  // Developers need to define this in their code like they have to do with all decorators.
+  interface FastifyInstance {
+    testOAuthName: fastifyOauth2.OAuth2Namespace;
+  }
+}
+
+/**
+ * Actual testing.
+ */
+expectType<fastifyOauth2.ProviderConfiguration>(auth);
+expectType<string[]>(scope);
+expectType<fastifyOauth2.Credentials>(credentials);
+expectType<fastifyOauth2.Credentials>(credentials);
+
+expectType<void>(fastifyOauth2(server, OAuth2Options, () => {}));
+expectError(fastifyOauth2()); // error because missing required arguments
+expectError(fastifyOauth2(server, {}, () => {})); // error because missing required plugin options
+
+expectAssignable<fastifyOauth2.ProviderConfiguration>(fastifyOauth2.FACEBOOK_CONFIGURATION);
+expectAssignable<fastifyOauth2.ProviderConfiguration>(fastifyOauth2.GITHUB_CONFIGURATION);
+expectAssignable<fastifyOauth2.ProviderConfiguration>(fastifyOauth2.GOOGLE_CONFIGURATION);
+expectAssignable<fastifyOauth2.ProviderConfiguration>(fastifyOauth2.LINKEDIN_CONFIGURATION);
+expectAssignable<fastifyOauth2.ProviderConfiguration>(fastifyOauth2.MICROSOFT_CONFIGURATION);
+expectAssignable<fastifyOauth2.ProviderConfiguration>(fastifyOauth2.SPOTIFY_CONFIGURATION);
+expectAssignable<fastifyOauth2.ProviderConfiguration>(fastifyOauth2.VKONTAKTE_CONFIGURATION);
+
+server.get('/testOauth/callback', async request => {
+  expectType<fastifyOauth2.OAuth2Namespace>(server.testOAuthName);
+
+  const token = await server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request);
+  expectType<fastifyOauth2.OAuth2Token>(token);
+  expectType<void>(
+    server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request, (t: fastifyOauth2.OAuth2Token): void => {}),
+  );
+
+  expectError<void>(await server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request)); // error because Promise should not return void
+  expectError<fastifyOauth2.OAuth2Token>(
+    server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request, (t: fastifyOauth2.OAuth2Token): void => {}),
+  ); // error because non-Promise function call should return void and have a callback argument
+  expectError<void>(server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request)); // error because function call does not pass a callback as second argument.
+
+  if (token.refresh_token) {
+    expectType<fastifyOauth2.OAuth2Token>(
+      await server.testOAuthName.getNewAccessTokenUsingRefreshToken(token.refresh_token, {}),
+    );
+    expectType<void>(
+      server.testOAuthName.getNewAccessTokenUsingRefreshToken(
+        token.refresh_token,
+        {},
+        (t: fastifyOauth2.OAuth2Token): void => {},
+      ),
+    );
+
+    expectError<void>(await server.testOAuthName.getNewAccessTokenUsingRefreshToken(token.refresh_token, {})); // error because Promise should not return void
+    expectError<fastifyOauth2.OAuth2Token>(
+      server.testOAuthName.getNewAccessTokenUsingRefreshToken(
+        token.refresh_token,
+        {},
+        (t: fastifyOauth2.OAuth2Token): void => {},
+      ),
+    ); // error because non-Promise function call should return void and have a callback argument
+    expectError<void>(server.testOAuthName.getNewAccessTokenUsingRefreshToken(token.refresh_token, {})); // error because function call does not pass a callback as second argument.
+  }
+
+  return {
+    access_token: token.access_token,
+  };
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "standard | snazzy",
     "unit": "tap test.js",
-    "test": "npm run lint && npm run unit",
+    "test": "npm run lint && npm run unit && npm run test:typescript",
     "test:typescript": "tsd",
     "coverage": "npm run unit -- --cov --coverage-report=html"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "standard | snazzy",
     "unit": "tap test.js",
     "test": "npm run lint && npm run unit",
+    "test:typescript": "tsd",
     "coverage": "npm run unit -- --cov --coverage-report=html"
   },
   "repository": {
@@ -30,7 +31,8 @@
     "simple-get": "^3.0.2",
     "snazzy": "^8.0.0",
     "standard": "^14.3.3",
-    "tap": "^12.0.0"
+    "tap": "^12.0.0",
+    "tsd": "^0.11.0"
   },
   "dependencies": {
     "es6-promisify": "^6.0.0",


### PR DESCRIPTION
Fixes #42.

Besides modifying the export, I also had to move the interfaces inside the `fastifyOauth2` namespace because the TS compiler would complain otherwise (`An export assignment cannot be used in a module with other exported elements.ts(2309)`), but that's fine because it does not break anything.

People who used this plugin with `esModuleInterop: true` or CommonJS imports will not be affected by these changes. Their code will work exactly the same. I tested all three import styles.

#### Checklist

- [x] run `npm run test` and `npm run coverage` - done it, although these are changes to type information, so it makes no difference in tests.
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
