### PR TITLE
feat: expose generateAuthrizationUri to decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Assuming we have registered multiple OAuth providers like this:
 
 ## Utilities
 
-This fastify plugin adds 2 utility decorators to your fastify instance using the same **namespace**:
+This fastify plugin adds 3 utility decorators to your fastify instance using the same **namespace**:
 
 - `getAccessTokenFromAuthorizationCodeFlow(request, callback)`: A function that uses the Authorization code flow to fetch an OAuth2 token using the data in the last request of the flow. If the callback is not passed it will return a promise. The object resulting from the callback call or the promise resolution is a *token response* object containing the following keys:
   - `access_token`
@@ -155,8 +155,16 @@ This fastify plugin adds 2 utility decorators to your fastify instance using the
   - `token_type` (generally `'bearer'`)
   - `expires_in` (number of seconds for the token to expire, e.g. `240000`)
 - `getNewAccessTokenUsingRefreshToken(refreshToken, params, callback)`: A function that takes a refresh token and retrieves a new *token response* object. This is generally useful with background processing workers to re-issue a new token when the original token has expired. The `params` argument is optional and it's an object that can be used to pass in extra parameters to the refresh request (e.g. a stricter set of scopes). If the callback is not passed this function will return a promise. The object resulting from the callback call or the promise resolution is a new *token response* object (see fields above).
+- `generateAuthorizationUri(requestObject)`: A function that returns the authorization uri. This is generally useful when you want to handle the redirect yourself in a specific route. The `requestObject` argument passes the request object to the `generateStateFunction`). You **don't** need to declare a `startRedirectPath` if you use this approach. Example of how you would use it:
 
-E.g. For `name: 'customOauth2'`, both helpers `getAccessTokenFromAuthorizationCodeFlow` and `getNewAccessTokenUsingRefreshToken` will become accessible like this:
+```js
+fastify.get('/external', { /* Hooks can be used here */ }, async (req, reply) => {
+  const authorizationEndpoint = fastify.customOAuth2.generateAuthorizationUri(req);
+  reply.redirect(authorizationEndpoint)
+});
+```
+
+E.g. For `name: 'customOauth2'`, the helpers `getAccessTokenFromAuthorizationCodeFlow` and `getNewAccessTokenUsingRefreshToken` will become accessible like this:
 
 - `fastify.customOauth2.getAccessTokenFromAuthorizationCodeFlow`
 - `fastify.customOauth2.getNewAccessTokenUsingRefreshToken`

--- a/index.js
+++ b/index.js
@@ -54,15 +54,21 @@ const oauthPlugin = fp(function (fastify, options, next) {
   const checkStateFunction = options.checkStateFunction || defaultCheckStateFunction
   const startRedirectPath = options.startRedirectPath
 
-  function startRedirectHandler (request, reply) {
-    const state = generateStateFunction(request)
+  function generateAuthorizationUri (requestObject) {
+    const state = generateStateFunction(requestObject)
     const urlOptions = Object.assign({}, callbackUriParams, {
       redirect_uri: callbackUri,
       scope: scope,
       state: state
     })
 
-    const authorizationUri = this[name].oauth2.authorizationCode.authorizeURL(urlOptions)
+    const authorizationUri = oauth2.authorizationCode.authorizeURL(urlOptions)
+    return authorizationUri
+  }
+
+  function startRedirectHandler (request, reply) {
+    const authorizationUri = generateAuthorizationUri(request)
+
     reply.redirect(authorizationUri)
   }
 
@@ -117,7 +123,8 @@ const oauthPlugin = fp(function (fastify, options, next) {
     fastify.decorate(name, {
       oauth2: oauth2,
       getAccessTokenFromAuthorizationCodeFlow,
-      getNewAccessTokenUsingRefreshToken
+      getNewAccessTokenUsingRefreshToken,
+      generateAuthorizationUri
     })
   } catch (e) {
     next(e)

--- a/test.js
+++ b/test.js
@@ -332,7 +332,7 @@ t.test('options.generateStateFunction with request', t => {
 
 t.test('generateAuthorizationUri redirect with request object', t => {
   t.plan(4)
-  const fastify = createFastify({ logger: true })
+  const fastify = createFastify()
 
   fastify.register(oauthPlugin, {
     name: 'theName',


### PR DESCRIPTION
Exposes `generateAuthorizationUri`to the decorator. This can allow route level flexibility if needed. Say a preValidation hook to check for auth before redirecting.

Ref: #45 

Example:
```js
fastify.get('/external', { preValidation: fastify.auth }, async (req, reply) => {
  const authorizationEndpoint = fastify.customOAuth2.generateAuthorizationUri(req);
  reply.redirect(authorizationEndpoint)
});
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
