### PR TITLE
feat: add apple sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ fastify.get('/login/facebook/callback', async function (request, reply) {
 
 You can choose some default setup to assign to `auth` option.
 
+- `APPLE_CONFIGURATION`
 - `FACEBOOK_CONFIGURATION`
 - `GITHUB_CONFIGURATION`
 - `LINKEDIN_CONFIGURATION`

--- a/examples/apple.js
+++ b/examples/apple.js
@@ -1,0 +1,60 @@
+'use strict'
+
+// This example assumes the use of the npm package apple-signin in your code.
+// This library is not included with fastify-oauth2. If you wish to implement
+// the verification part of Apple's Sign In REST API yourself,
+// look at https://github.com/Techofficer/node-apple-signin to see how they did
+// it, or look at https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api
+// for more details on how to do it from scratch.
+
+const fastify = require('fastify')({ logger: { level: 'trace' } })
+const appleSignin = require('apple-signin')
+
+const oauthPlugin = require('..')
+
+const CLIENT_ID = '<CLIENT_ID>'
+
+fastify.register(oauthPlugin, {
+  name: 'appleOAuth2',
+  credentials: {
+    client: {
+      id: CLIENT_ID,
+      // See https://github.com/Techofficer/node-apple-signin/blob/master/source/index.js
+      // for how to create the secret.
+      secret: '<CLIENT_SECRET>'
+    },
+    auth: oauthPlugin.APPLE_CONFIGURATION
+  },
+  startRedirectPath: '/login/apple',
+  callbackUri: 'http://localhost:3000/login/apple/callback'
+})
+
+fastify.get('/login/apple/callback', function (request, reply) {
+  this.appleOAuth2.getAccessTokenFromAuthorizationCodeFlow(
+    request,
+    (err, result) => {
+      if (err) {
+        reply.send(err)
+        return
+      }
+
+      appleSignin.verifyIdToken(
+        result.id_token,
+        CLIENT_ID
+      )
+        .then(payload => {
+          // Find all the available fields (like email) in
+          // https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple
+          const userAppleId = payload.sub
+
+          reply.send(userAppleId)
+        })
+        .catch(err => {
+          // Token is not verified
+          reply.send(err)
+        })
+    }
+  )
+})
+
+fastify.listen(3000)

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ declare function fastifyOauth2 (
 ): void;
 
 declare namespace fastifyOauth2 {
+  const APPLE_CONFIGURATION: ProviderConfiguration;
   const FACEBOOK_CONFIGURATION: ProviderConfiguration;
   const GITHUB_CONFIGURATION: ProviderConfiguration;
   const LINKEDIN_CONFIGURATION: ProviderConfiguration;

--- a/index.js
+++ b/index.js
@@ -137,6 +137,13 @@ const oauthPlugin = fp(function (fastify, options, next) {
   name: 'fastify-oauth2'
 })
 
+oauthPlugin.APPLE_CONFIGURATION = {
+  authorizeHost: 'https://appleid.apple.com',
+  authorizePath: '/auth/authorize',
+  tokenHost: 'https://appleid.apple.com',
+  tokenPath: '/auth/token'
+}
+
 oauthPlugin.FACEBOOK_CONFIGURATION = {
   authorizeHost: 'https://facebook.com',
   authorizePath: '/v6.0/dialog/oauth',


### PR DESCRIPTION
Adds support for Apple Sign In by following the REST API docs in https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api and also the implementation from `apple-signin` (https://www.npmjs.com/package/apple-signin). 

The example shows how to get the `CLIENT_SECRET` by using `apple-signin`, but users could also choose to implement that part themselves. Either way, that's kind of separate from what `fastify-oauth2` is in charge of.

Let me know if there seems to be anything missing. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] ~tests and/or benchmarks are included~
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
