### PR TITLE
Fix for issue 116 with a failed redirect by Apple authorization URL when scope with value 'name' or 'email' is requested

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,12 +65,14 @@ const oauthPlugin = fp(function (fastify, options, next) {
 
   function generateAuthorizationUri (requestObject) {
     const state = generateStateFunction(requestObject)
+    const scopeName = Array.isArray(scope) ? scope.join(' ') : scope
+    const hasResponseMode = scopeName.includes('email') || scopeName.includes('name')
     const urlOptions = Object.assign({}, callbackUriParams, {
       redirect_uri: callbackUri,
       scope: scope,
-      state: state
+      state: state,
+      ...(hasResponseMode && { response_mode: 'form_post' })
     })
-
     const authorizationUri = oauth2.authorizationCode.authorizeURL(urlOptions)
     return authorizationUri
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-oauth2",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "Perform login using oauth2 protocol",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added 
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Description
This fix provides a bugfix for issue #116. No changes for documentation are needed here, because it's implemented and used under the hood regardless of library usage.

![image](https://user-images.githubusercontent.com/9191544/137324787-b3207d2a-36e6-4902-b6ca-60b8042f17d9.png)

All tests are passed:

![image](https://user-images.githubusercontent.com/9191544/137325079-3c4ed7ed-391b-4642-9520-d7c4bf104d26.png)

