### PR TITLE
feat: Add Epic Games configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ You can choose some default setup to assign to `auth` option.
 - `TWITCH_CONFIGURATION`
 - `VATSIM_CONFIGURATION`
 - `VATSIM_DEV_CONFIGURATION`
+- `EPIC_GAMES_CONFIGURATION`
 
 ### Custom configuration
 

--- a/examples/epic-games.js
+++ b/examples/epic-games.js
@@ -24,7 +24,7 @@ fastify.get('/login/eg/callback', async (req, reply) => {
   reply.send({ access_token: token.access_token })
 })
 
-fastify.listen(9_000, (err, address) => {
+fastify.listen(process.env.PORT, (err, address) => {
   if (err) {
     fastify.log.error(err)
     process.exit(1)

--- a/examples/epic-games.js
+++ b/examples/epic-games.js
@@ -1,0 +1,33 @@
+const fastify = require('fastify')({ logger: { level: 'trace' } })
+
+// const oauthPlugin = require('fastify-oauth2')
+const oauthPlugin = require('..')
+
+fastify.register(oauthPlugin, {
+  name: 'egOAuth2',
+  scope: ['basic_profile'], // 'basic_profile', 'friends_list', 'presence',
+  credentials: {
+    client: {
+      id: process.env.CLIENT_ID,
+      secret: process.env.CLIENT_SECRET
+    },
+    auth: oauthPlugin.EPIC_GAMES_CONFIGURATION
+  },
+  startRedirectPath: '/login/eg',
+  callbackUri: `http://localhost:${process.env.PORT}/login/eg/callback`
+})
+
+fastify.get('/login/eg/callback', async (req, reply) => {
+  const token = await fastify.egOAuth2.getAccessTokenFromAuthorizationCodeFlow(req)
+
+  req.log.info('The Epic Games token is %o', token)
+  reply.send({ access_token: token.access_token })
+})
+
+fastify.listen(9_000, (err, address) => {
+  if (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
+  fastify.log.info(`server listening on ${address}`)
+})

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ interface FastifyOAuth2 {
   TWITCH_CONFIGURATION: ProviderConfiguration;
   VATSIM_CONFIGURATION: ProviderConfiguration;
   VATSIM_DEV_CONFIGURATION: ProviderConfiguration;
+  EPIC_GAMES_CONFIGURATION: ProviderConfiguration;
 }
 
 export const fastifyOauth2: FastifyPluginCallback<FastifyOAuth2Options> & FastifyOAuth2

--- a/index.js
+++ b/index.js
@@ -251,4 +251,11 @@ oauthPlugin.VATSIM_DEV_CONFIGURATION = {
   tokenPath: '/oauth/token'
 }
 
+oauthPlugin.EPIC_GAMES_CONFIGURATION = {
+  authorizeHost: 'https://www.epicgames.com',
+  authorizePath: '/id/authorize',
+  tokenHost: 'https://api.epicgames.dev',
+  tokenPath: '/epic/oauth/v1/token'
+}
+
 module.exports = oauthPlugin

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -59,6 +59,7 @@ expectAssignable<ProviderConfiguration>(fastifyOauth2.VKONTAKTE_CONFIGURATION);
 expectAssignable<ProviderConfiguration>(fastifyOauth2.TWITCH_CONFIGURATION);
 expectAssignable<ProviderConfiguration>(fastifyOauth2.VATSIM_CONFIGURATION);
 expectAssignable<ProviderConfiguration>(fastifyOauth2.VATSIM_DEV_CONFIGURATION);
+expectAssignable<ProviderConfiguration>(fastifyOauth2.EPIC_GAMES_CONFIGURATION);
 
 server.get('/testOauth/callback', async request => {
   expectType<OAuth2Namespace>(server.testOAuthName);


### PR DESCRIPTION
Adds support for Epic Games by following the REST API documentation [here](https://dev.epicgames.com/docs/services/en-US/WebAPIRef/AuthWebAPI/index.html).

Let me know if there seems to be anything missing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Test

```
> @fastify/oauth2@5.0.0 test
> npm run lint && npm run unit && npm run test:typescript


> @fastify/oauth2@5.0.0 lint
> standard | snazzy


> @fastify/oauth2@5.0.0 unit
> tap -J "test/*.test.js"

​ PASS ​ test/plugin.test.js 56 OK 479.296ms



  🌈 SUMMARY RESULTS 🌈  


Suites:   ​1 passed​, ​1 of 1 completed​
Asserts:  ​​​56 passed​, ​of 56​
​Time:​   ​2s​
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |      100 |     100 |     100 | 
 index.js |     100 |      100 |     100 |     100 | 
----------|---------|----------|---------|---------|-------------------

> @fastify/oauth2@5.0.0 test:typescript
> tsd
```