### PR TITLE
fix: way to get accesstoken and deprecated option

### DIFF
--- a/examples/google.js
+++ b/examples/google.js
@@ -31,7 +31,7 @@ fastify.get('/login/google/callback', function (request, reply) {
       url: 'https://www.googleapis.com/oauth2/v2/userinfo',
       method: 'GET',
       headers: {
-        Authorization: 'Bearer ' + result.access_token
+        Authorization: 'Bearer ' + result.token.access_token
       },
       json: true
     }, function (err, res, data) {

--- a/examples/spotify.js
+++ b/examples/spotify.js
@@ -24,9 +24,4 @@ fastify.get('/login/spotify/callback', async (req, reply) => {
   reply.send({ access_token: result.token.access_token })
 })
 
-fastify.listen(process.env.PORT, (err) => {
-  if (err) {
-    fastify.log.error(err)
-    process.exit(1)
-  }
-})
+fastify.listen({ port: process.env.PORT })

--- a/examples/spotify.js
+++ b/examples/spotify.js
@@ -18,10 +18,10 @@ fastify.register(oauthPlugin, {
 })
 
 fastify.get('/login/spotify/callback', async (req, reply) => {
-  const token = await fastify.Spotify.getAccessTokenFromAuthorizationCodeFlow(req)
+  const result = await fastify.Spotify.getAccessTokenFromAuthorizationCodeFlow(req)
 
-  req.log.info('The Spotify token is %o', token)
-  reply.send({ access_token: token.access_token })
+  req.log.info('The Spotify token is %o', result.token)
+  reply.send({ access_token: result.token.access_token })
 })
 
 fastify.listen(process.env.PORT, (err) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

It seems that the `token` param is missing for reaching `access_token`.
I've only tested for `example/google.js` and `example/spotify.js` so I'll commit them only but I think this fix is required for other examples too...


#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
