### PR TITLE
feat: introduce option to set additional getToken parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ fastify.register(oauthPlugin, {
 });
 ```
 
+## Set custom tokenRequest body Parameters
+
+The `tokenRequestParams` parameter accepts an object that will be translated to additional parameters in the POST body
+when requesting access tokens via the service’s token endpoint.
+
 ## Examples
 
 See the [`example/`](./examples/) folder for more examples.

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,7 @@ export interface FastifyOAuth2Options {
   credentials: Credentials;
   callbackUri: string;
   callbackUriParams?: Object;
+  getTokenParams?: Object;
   generateStateFunction?: Function;
   checkStateFunction?: Function;
   startRedirectPath: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ export interface FastifyOAuth2Options {
   credentials: Credentials;
   callbackUri: string;
   callbackUriParams?: Object;
-  getTokenParams?: Object;
+  tokenRequestParams?: Object;
   generateStateFunction?: Function;
   checkStateFunction?: Function;
   startRedirectPath: string;

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const defaultState = require('crypto').randomBytes(10).toString('hex')
 const fp = require('fastify-plugin')
 const { AuthorizationCode } = require('simple-oauth2')
 const kGenerateCallbackUriParams = Symbol.for('fastify-oauth2.generate-callback-uri-params')
-const kGenerateGetTokenParams = Symbol.for('fastify-oauth2.generate-get-token-params')
+const kGenerateTokenRequestParams = Symbol.for('fastify-oauth2.generate-token-request-params')
 
 const promisify = require('util').promisify
 const callbackify = require('util').callbackify
@@ -26,8 +26,8 @@ function defaultGenerateCallbackUriParams (callbackUriParams) {
   return callbackUriParams
 }
 
-function defaultGenerateGetTokenParams (getTokenParams) {
-  return getTokenParams
+function defaultGenerateTokenRequestParams (tokenRequestParams) {
+  return tokenRequestParams
 }
 
 const oauthPlugin = fp(function (fastify, options, next) {
@@ -43,8 +43,8 @@ const oauthPlugin = fp(function (fastify, options, next) {
   if (options.callbackUriParams && typeof options.callbackUriParams !== 'object') {
     return next(new Error('options.callbackUriParams should be a object'))
   }
-  if (options.getTokenParams && typeof options.getTokenParams !== 'object') {
-    return next(new Error('options.getTokenParams should be a object'))
+  if (options.tokenRequestParams && typeof options.tokenRequestParams !== 'object') {
+    return next(new Error('options.tokenRequestParams should be a object'))
   }
   if (options.generateStateFunction && typeof options.generateStateFunction !== 'function') {
     return next(new Error('options.generateStateFunction should be a function'))
@@ -69,12 +69,12 @@ const oauthPlugin = fp(function (fastify, options, next) {
   const credentials = options.credentials
   const callbackUri = options.callbackUri
   const callbackUriParams = options.callbackUriParams || {}
-  const getTokenParams = options.getTokenParams || {}
+  const tokenRequestParams = options.tokenRequestParams || {}
   const scope = options.scope
   const generateStateFunction = options.generateStateFunction || defaultGenerateStateFunction
   const checkStateFunction = options.checkStateFunction || defaultCheckStateFunction
   const generateCallbackUriParams = (credentials.auth && credentials.auth[kGenerateCallbackUriParams]) || defaultGenerateCallbackUriParams
-  const generateGetTokenParams = (credentials.auth && credentials.auth[kGenerateGetTokenParams]) || defaultGenerateGetTokenParams
+  const generateTokenRequestParams = (credentials.auth && credentials.auth[kGenerateTokenRequestParams]) || defaultGenerateTokenRequestParams
   const startRedirectPath = options.startRedirectPath
   const tags = options.tags || []
   const schema = options.schema || { tags }
@@ -98,12 +98,12 @@ const oauthPlugin = fp(function (fastify, options, next) {
   }
 
   const cbk = function (o, code, callback) {
-    const urlOptions = Object.assign({}, generateGetTokenParams(getTokenParams), {
+    const body = Object.assign({}, generateTokenRequestParams(tokenRequestParams), {
       code,
       redirect_uri: callbackUri
     })
 
-    return callbackify(o.oauth2.getToken.bind(o.oauth2, urlOptions))(callback)
+    return callbackify(o.oauth2.getToken.bind(o.oauth2, body))(callback)
   }
 
   function getAccessTokenFromAuthorizationCodeFlowCallbacked (request, callback) {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const defaultState = require('crypto').randomBytes(10).toString('hex')
 const fp = require('fastify-plugin')
 const { AuthorizationCode } = require('simple-oauth2')
 const kGenerateCallbackUriParams = Symbol.for('fastify-oauth2.generate-callback-uri-params')
-const kGenerateTokenRequestParams = Symbol.for('fastify-oauth2.generate-token-request-params')
 
 const promisify = require('util').promisify
 const callbackify = require('util').callbackify
@@ -24,10 +23,6 @@ function defaultCheckStateFunction (state, callback) {
 
 function defaultGenerateCallbackUriParams (callbackUriParams) {
   return callbackUriParams
-}
-
-function defaultGenerateTokenRequestParams (tokenRequestParams) {
-  return tokenRequestParams
 }
 
 const oauthPlugin = fp(function (fastify, options, next) {
@@ -74,7 +69,6 @@ const oauthPlugin = fp(function (fastify, options, next) {
   const generateStateFunction = options.generateStateFunction || defaultGenerateStateFunction
   const checkStateFunction = options.checkStateFunction || defaultCheckStateFunction
   const generateCallbackUriParams = (credentials.auth && credentials.auth[kGenerateCallbackUriParams]) || defaultGenerateCallbackUriParams
-  const generateTokenRequestParams = (credentials.auth && credentials.auth[kGenerateTokenRequestParams]) || defaultGenerateTokenRequestParams
   const startRedirectPath = options.startRedirectPath
   const tags = options.tags || []
   const schema = options.schema || { tags }
@@ -98,7 +92,7 @@ const oauthPlugin = fp(function (fastify, options, next) {
   }
 
   const cbk = function (o, code, callback) {
-    const body = Object.assign({}, generateTokenRequestParams(tokenRequestParams), {
+    const body = Object.assign({}, tokenRequestParams, {
       code,
       redirect_uri: callbackUri
     })

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -297,7 +297,7 @@ t.test('options.callbackUriParams', t => {
   })
 })
 
-t.test('options.getTokenParams should be an object', t => {
+t.test('options.tokenRequestParams should be an object', t => {
   t.plan(1)
 
   const fastify = createFastify({ logger: { level: 'silent' } })
@@ -312,14 +312,14 @@ t.test('options.getTokenParams should be an object', t => {
       auth: oauthPlugin.GITHUB_CONFIGURATION
     },
     callbackUri: '/callback',
-    getTokenParams: 1
+    tokenRequestParams: 1
   })
     .ready(err => {
-      t.strictSame(err.message, 'options.getTokenParams should be a object')
+      t.strictSame(err.message, 'options.tokenRequestParams should be a object')
     })
 })
 
-t.test('options.getTokenParams', t => {
+t.test('options.tokenRequestParams', t => {
   const fastify = createFastify({ logger: { level: 'silent' } })
   const oAuthCode = '123456789'
 
@@ -340,7 +340,7 @@ t.test('options.getTokenParams', t => {
     checkStateFunction: function(state, callback) {
       callback()
     },
-    getTokenParams: {
+    tokenRequestParams: {
       param1: '123'
     },
     scope: ['notifications']

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -297,6 +297,28 @@ t.test('options.callbackUriParams', t => {
   })
 })
 
+t.test('options.getTokenParams should be an object', t => {
+  t.plan(1)
+
+  const fastify = createFastify({ logger: { level: 'silent' } })
+
+  fastify.register(oauthPlugin, {
+    name: 'the-name',
+    credentials: {
+      client: {
+        id: 'my-client-id',
+        secret: 'my-secret'
+      },
+      auth: oauthPlugin.GITHUB_CONFIGURATION
+    },
+    callbackUri: '/callback',
+    getTokenParams: 1
+  })
+    .ready(err => {
+      t.strictSame(err.message, 'options.getTokenParams should be a object')
+    })
+})
+
 t.test('options.generateStateFunction with request', t => {
   t.plan(5)
   const fastify = createFastify()

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -320,6 +320,8 @@ t.test('options.tokenRequestParams should be an object', t => {
 })
 
 t.test('options.tokenRequestParams', t => {
+  t.plan(2)
+
   const fastify = createFastify({ logger: { level: 'silent' } })
   const oAuthCode = '123456789'
 
@@ -337,7 +339,7 @@ t.test('options.tokenRequestParams', t => {
     generateStateFunction: function () {
       return 'dummy'
     },
-    checkStateFunction: function(state, callback) {
+    checkStateFunction: function (state, callback) {
       callback()
     },
     tokenRequestParams: {
@@ -378,7 +380,6 @@ t.test('options.tokenRequestParams', t => {
       t.error(err)
 
       githubScope.done()
-      t.end()
     })
   })
 })


### PR DESCRIPTION
Adds an option to configure additional parameters for `getToken` calls as described in #177

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
