### PR TITLE
Adds "id_token" property to Token type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,6 +35,7 @@ declare namespace fastifyOauth2 {
     token_type: 'bearer';
     access_token: string;
     refresh_token?: string;
+    id_token?: string;
     expires_in: number;
     expires_at: Date;
   }


### PR DESCRIPTION
I am using Google oauth2 flow and the token returned by `getAccessTokenFromAuthorizationCodeFlow` contains also an id_token, but it's not listed in the TypeScript typings:

```typescript
const { token } = await this.googleOAuth2.getAccessTokenFromAuthorizationCodeFlow(
  request
)

token.id_token // this one is not listed in the typings
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
