### PR TITLE
make adjustment to google configuration property value

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,8 +201,9 @@ fastifyOauth2.LINKEDIN_CONFIGURATION = {
 fastifyOauth2.GOOGLE_CONFIGURATION = {
   authorizeHost: 'https://accounts.google.com',
   authorizePath: '/o/oauth2/v2/auth',
-  tokenHost: 'https://www.googleapis.com',
-  tokenPath: '/oauth2/v4/token'
+  tokenHost: 'https://oauth2.googleapis.com',
+  tokenPath: '/token',
+  revokePath: '/revoke'
 }
 
 fastifyOauth2.MICROSOFT_CONFIGURATION = {


### PR DESCRIPTION
I made updates to the token-host, token-path, and revoke-path of the google configuration.  [reference](https://github.com/googleapis/google-auth-library-nodejs/blob/3563c16e2376729e399fefc0b1fad7bff78c296e/src/auth/oauth2client.ts#L491) 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
