### PR TITLE
[211] fix generateStateFunction call when using custom start redirect handler with generateAuthorizationUri

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -450,7 +450,7 @@ t.test('generateAuthorizationUri redirect with request object', t => {
   })
 
   fastify.get('/gh', function (request, reply) {
-    const redirectUrl = this.theName.generateAuthorizationUri(request, 'generated_code')
+    const redirectUrl = this.theName.generateAuthorizationUri(request, reply)
     return reply.redirect(redirectUrl)
   })
 


### PR DESCRIPTION
[Issue 211](https://github.com/fastify/fastify-oauth2/issues/211)

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
