### PR TITLE
Fix generateAuthorizationUri() typedef signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,11 +245,11 @@ fastify.googleOAuth2.getNewAccessTokenUsingRefreshToken(currentAccessToken, (err
 });
 ```
 
-- `generateAuthorizationUri(requestObject)`: A function that returns the authorization uri. This is generally useful when you want to handle the redirect yourself in a specific route. The `requestObject` argument passes the request object to the `generateStateFunction`). You **do not** need to declare a `startRedirectPath` if you use this approach. Example of how you would use it:
+- `generateAuthorizationUri(requestObject, replyObject)`: A function that returns the authorization uri. This is generally useful when you want to handle the redirect yourself in a specific route. The `requestObject` argument passes the request object to the `generateStateFunction`). You **do not** need to declare a `startRedirectPath` if you use this approach. Example of how you would use it:
 
 ```js
 fastify.get('/external', { /* Hooks can be used here */ }, async (req, reply) => {
-  const authorizationEndpoint = fastify.customOAuth2.generateAuthorizationUri(req);
+  const authorizationEndpoint = fastify.customOAuth2.generateAuthorizationUri(req, reply);
   reply.redirect(authorizationEndpoint)
 });
 ```

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { FastifyPluginCallback, FastifyRequest } from 'fastify';
+import { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
 
 interface FastifyOauth2 extends FastifyPluginCallback<fastifyOauth2.FastifyOAuth2Options> {
   APPLE_CONFIGURATION: fastifyOauth2.ProviderConfiguration;
@@ -127,6 +127,7 @@ declare namespace fastifyOauth2 {
 
     generateAuthorizationUri(
       request: FastifyRequest,
+      reply: FastifyReply,
     ): string;
   }
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -86,7 +86,7 @@ expectAssignable<ProviderConfiguration>(fastifyOauth2.VATSIM_CONFIGURATION);
 expectAssignable<ProviderConfiguration>(fastifyOauth2.VATSIM_DEV_CONFIGURATION);
 expectAssignable<ProviderConfiguration>(fastifyOauth2.EPIC_GAMES_CONFIGURATION);
 
-server.get('/testOauth/callback', async request => {
+server.get('/testOauth/callback', async (request, reply) => {
   expectType<OAuth2Namespace>(server.testOAuthName);
 
   expectType<OAuth2Token>(await server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request));
@@ -128,7 +128,8 @@ server.get('/testOauth/callback', async request => {
     expectError<void>(server.testOAuthName.getNewAccessTokenUsingRefreshToken(token.token, {})); // error because function call does not pass a callback as second argument.
   }
 
-  expectType<string>(server.testOAuthName.generateAuthorizationUri(request));
+  expectType<string>(server.testOAuthName.generateAuthorizationUri(request, reply));
+  expectError<string>(server.testOAuthName.generateAuthorizationUri(request)); // error because missing reply argument
 
   return {
     access_token: token.token.access_token,


### PR DESCRIPTION
The typescript definition for the `generateAuthorizationUri()` method is missing the `reply` argument

https://github.com/fastify/fastify-oauth2/blob/2009b29cf9c621b8237954986f3821f0d1e05530/index.js#L82

This PR adds the missing argument to the typescript definition, a simple tsd test to make sure the signature is correct and updates the `generateAuthorizationUri()` example in the README file.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
