### PR TITLE
feat: allow default cookie options to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ fastify.register(require('@fastify/cookie'), cookieOptions)
 fastify.register(oauthPlugin, oauthOptions)
 ```
 
+Cookies are by default `httpOnly`, `sameSite: Lax`. If this does not suit your use case, it is possible to override the default cookie settings by providing options in the configuration object, for example
+
+```js
+fastify.register(oauthPlugin, {
+  ...,
+  cookie: {
+    secure: true,
+    sameSite: 'none'
+  }
+})
+```
+
 ### Preset configurations
 
 You can choose some default setup to assign to `auth` option.

--- a/index.js
+++ b/index.js
@@ -78,10 +78,11 @@ function fastifyOauth2 (fastify, options, next) {
   const startRedirectPath = options.startRedirectPath
   const tags = options.tags || []
   const schema = options.schema || { tags }
-  const cookieOpts = Object.assign({}, options.cookie, {
+  const defaultCookieOpts = {
     httpOnly: true,
     sameSite: 'lax'
   }
+  const cookieOpts = Object.assign({}, defaultCookieOpts, options.cookie)
 
   function generateAuthorizationUri (request, reply) {
     const state = generateStateFunction(request)

--- a/index.js
+++ b/index.js
@@ -78,14 +78,15 @@ function fastifyOauth2 (fastify, options, next) {
   const startRedirectPath = options.startRedirectPath
   const tags = options.tags || []
   const schema = options.schema || { tags }
+  const cookieOpts = options.cookie || {
+    httpOnly: true,
+    sameSite: 'lax'
+  }
 
   function generateAuthorizationUri (request, reply) {
     const state = generateStateFunction(request)
 
-    reply.setCookie('oauth2-redirect-state', state, {
-      httpOnly: true,
-      sameSite: 'lax'
-    })
+    reply.setCookie('oauth2-redirect-state', state, cookieOpts)
 
     const urlOptions = Object.assign({}, generateCallbackUriParams(callbackUriParams, request, scope, state), {
       redirect_uri: callbackUri,

--- a/index.js
+++ b/index.js
@@ -81,11 +81,7 @@ function fastifyOauth2 (fastify, options, next) {
   const startRedirectPath = options.startRedirectPath
   const tags = options.tags || []
   const schema = options.schema || { tags }
-  const defaultCookieOpts = {
-    httpOnly: true,
-    sameSite: 'lax'
-  }
-  const cookieOpts = Object.assign({}, defaultCookieOpts, options.cookie)
+  const cookieOpts = Object.assign({ httpOnly: true, sameSite: 'lax' }, options.cookie)
 
   function generateAuthorizationUri (request, reply) {
     const state = generateStateFunction(request)

--- a/index.js
+++ b/index.js
@@ -61,6 +61,9 @@ function fastifyOauth2 (fastify, options, next) {
   if (options.schema && typeof options.schema !== 'object') {
     return next(new Error('options.schema should be a object'))
   }
+  if (options.cookie && typeof options.cookie !== 'object') {
+    return next(new Error('options.cookie should be an object'))
+  }
 
   if (!fastify.hasReplyDecorator('cookie')) {
     fastify.register(require('@fastify/cookie'))

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function fastifyOauth2 (fastify, options, next) {
   const startRedirectPath = options.startRedirectPath
   const tags = options.tags || []
   const schema = options.schema || { tags }
-  const cookieOpts = options.cookie || {
+  const cookieOpts = Object.assign({}, options.cookie, {
     httpOnly: true,
     sameSite: 'lax'
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -602,6 +602,28 @@ t.test('options.schema should be a object', t => {
     })
 })
 
+t.test('options.cookie should be an object', t => {
+  t.plan(1)
+
+  const fastify = createFastify({ logger: { level: 'silent' } })
+
+  fastify.register(fastifyOauth2, {
+    name: 'the-name',
+    credentials: {
+      client: {
+        id: 'my-client-id',
+        secret: 'my-secret'
+      },
+      auth: fastifyOauth2.GITHUB_CONFIGURATION
+    },
+    callbackUri: '/callback',
+    cookie: 1
+  })
+    .ready(err => {
+      t.strictSame(err.message, 'options.cookie should be an object')
+    })
+})
+
 t.test('options.schema', t => {
   const fastify = createFastify({ logger: { level: 'silent' }, exposeHeadRoutes: false })
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,7 +30,7 @@ declare namespace fastifyOauth2 {
     startRedirectPath?: string;
     tags?: string[];
     schema?: object;
-    cookie?: object;
+    cookie?: CookieSerializeOptions;
   }
 
   export interface Token {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
+import { CookieSerializeOptions } from "@fastify/cookie";
 
 interface FastifyOauth2 extends FastifyPluginCallback<fastifyOauth2.FastifyOAuth2Options> {
   APPLE_CONFIGURATION: fastifyOauth2.ProviderConfiguration;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,6 +29,7 @@ declare namespace fastifyOauth2 {
     startRedirectPath?: string;
     tags?: string[];
     schema?: object;
+    cookie?: object;
   }
 
   export interface Token {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -31,6 +31,7 @@ const OAuth2Options: FastifyOAuth2Options = {
   generateStateFunction: () => {},
   checkStateFunction: () => {},
   startRedirectPath: '/login/testOauth',
+  cookie: {}
 };
 
 const server = fastify();

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -31,7 +31,10 @@ const OAuth2Options: FastifyOAuth2Options = {
   generateStateFunction: () => {},
   checkStateFunction: () => {},
   startRedirectPath: '/login/testOauth',
-  cookie: {}
+  cookie: {
+    secure: true,
+    sameSite: 'none'
+  }
 };
 
 const server = fastify();


### PR DESCRIPTION
In my use-case, i'm in an iframe with a strict security policy i cannot change.

This results in `lax` cookies being blocked.

However, `secure`, `sameSite: none` cookies are not, which resolves this problem.

Seemed a simple enough change for me to just do a pr for.

Thanks for the great work on the package.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and ~~`npm run benchmark`~~
- [x] tests and/or ~~benchmarks are included~~
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


#### Test results

```
➜  fastify-oauth2 git:(master) npm run test

> @fastify/oauth2@7.2.2 test
> npm run test:unit && npm run test:typescript


> @fastify/oauth2@7.2.2 test:unit
> tap

​ PASS ​ test/index.test.js 112 OK 138.59ms
​

                         
  🌈 SUMMARY RESULTS 🌈  
                         
​
Suites:   ​1 passed​, ​1 of 1 completed​
Asserts:  ​​​112 passed​, ​of 112​
​Time:​   ​543.749ms​
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |      100 |     100 |     100 |                   
 index.js |     100 |      100 |     100 |     100 |                   
----------|---------|----------|---------|---------|-------------------
```