### PR TITLE
Improve out of the box types by using a prefix when decorating

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,20 +220,20 @@ See the [`example/`](./examples/) folder for more examples.
 ## Reference
 
 This Fastify plugin decorates the fastify instance with the [`simple-oauth2`](https://github.com/lelylan/simple-oauth2)
-instance inside a **namespace** specified by the property `name`.
+instance inside a **namespace** specified by the property `name` both with and without a `fastifyOauth2` prefix.
 
 E.g. For `name: 'customOauth2'`, the `simple-oauth2` instance will become accessible like this:
 
-`fastify.customOauth2.oauth2`
+`fastify.fastifyOauth2CustomOauth2.oauth2` and `fastify.customOauth2.oauth2`
 
 In this manner we are able to register multiple OAuth providers and each OAuth providers `simple-oauth2` instance will live in it's own **namespace**.
 
 E.g.
 
-- `fastify.facebook.oauth2`
-- `fastify.github.oauth2`
-- `fastify.spotify.oauth2`
-- `fastify.vkontakte.oauth2`
+- `fastify.fastifyOauth2Facebook.oauth2`
+- `fastify.fastifyOauth2Github.oauth2`
+- `fastify.fastifyOauth2Spotify.oauth2`
+- `fastify.fastifyOauth2Vkontakte.oauth2`
 
 Assuming we have registered multiple OAuth providers like this:
 
@@ -262,7 +262,7 @@ fastify.googleOAuth2.getNewAccessTokenUsingRefreshToken(currentAccessToken, (err
 
 ```js
 fastify.get('/external', { /* Hooks can be used here */ }, async (req, reply) => {
-  const authorizationEndpoint = fastify.customOAuth2.generateAuthorizationUri(req, reply);
+  const authorizationEndpoint = fastify.fastifyOauth2CustomOAuth2.generateAuthorizationUri(req, reply);
   reply.redirect(authorizationEndpoint)
 });
 ```
@@ -281,8 +281,8 @@ fastify.googleOAuth2.revokeAllToken(currentAccessToken, undefined, (err) => {
 ```
 E.g. For `name: 'customOauth2'`, the helpers `getAccessTokenFromAuthorizationCodeFlow` and `getNewAccessTokenUsingRefreshToken` will become accessible like this:
 
-- `fastify.customOauth2.getAccessTokenFromAuthorizationCodeFlow`
-- `fastify.customOauth2.getNewAccessTokenUsingRefreshToken`
+- `fastify.fastifyOauth2CustomOauth2.getAccessTokenFromAuthorizationCodeFlow`
+- `fastify.fastifyOauth2CustomOauth2.getNewAccessTokenUsingRefreshToken`
 
 ## Usage with TypeScript
 
@@ -300,6 +300,8 @@ declare module 'fastify' {
   }
 }
 ```
+
+All auth configurations are made available with a `fastifyOauth2` prefix that's typed to `OAuth2Namespace | undefined`.
 
 ## Provider Quirks
 

--- a/README.md
+++ b/README.md
@@ -220,20 +220,20 @@ See the [`example/`](./examples/) folder for more examples.
 ## Reference
 
 This Fastify plugin decorates the fastify instance with the [`simple-oauth2`](https://github.com/lelylan/simple-oauth2)
-instance inside a **namespace** specified by the property `name` both with and without a `fastifyOauth2` prefix.
+instance inside a **namespace** specified by the property `name` both with and without an `oauth2` prefix.
 
 E.g. For `name: 'customOauth2'`, the `simple-oauth2` instance will become accessible like this:
 
-`fastify.fastifyOauth2CustomOauth2.oauth2` and `fastify.customOauth2.oauth2`
+`fastify.oauth2CustomOauth2.oauth2` and `fastify.customOauth2.oauth2`
 
 In this manner we are able to register multiple OAuth providers and each OAuth providers `simple-oauth2` instance will live in it's own **namespace**.
 
 E.g.
 
-- `fastify.fastifyOauth2Facebook.oauth2`
-- `fastify.fastifyOauth2Github.oauth2`
-- `fastify.fastifyOauth2Spotify.oauth2`
-- `fastify.fastifyOauth2Vkontakte.oauth2`
+- `fastify.oauth2Facebook.oauth2`
+- `fastify.oauth2Github.oauth2`
+- `fastify.oauth2Spotify.oauth2`
+- `fastify.oauth2Vkontakte.oauth2`
 
 Assuming we have registered multiple OAuth providers like this:
 
@@ -262,7 +262,7 @@ fastify.googleOAuth2.getNewAccessTokenUsingRefreshToken(currentAccessToken, (err
 
 ```js
 fastify.get('/external', { /* Hooks can be used here */ }, async (req, reply) => {
-  const authorizationEndpoint = fastify.fastifyOauth2CustomOAuth2.generateAuthorizationUri(req, reply);
+  const authorizationEndpoint = fastify.oauth2CustomOAuth2.generateAuthorizationUri(req, reply);
   reply.redirect(authorizationEndpoint)
 });
 ```
@@ -281,8 +281,8 @@ fastify.googleOAuth2.revokeAllToken(currentAccessToken, undefined, (err) => {
 ```
 E.g. For `name: 'customOauth2'`, the helpers `getAccessTokenFromAuthorizationCodeFlow` and `getNewAccessTokenUsingRefreshToken` will become accessible like this:
 
-- `fastify.fastifyOauth2CustomOauth2.getAccessTokenFromAuthorizationCodeFlow`
-- `fastify.fastifyOauth2CustomOauth2.getNewAccessTokenUsingRefreshToken`
+- `fastify.oauth2CustomOauth2.getAccessTokenFromAuthorizationCodeFlow`
+- `fastify.oauth2CustomOauth2.getNewAccessTokenUsingRefreshToken`
 
 ## Usage with TypeScript
 
@@ -301,7 +301,7 @@ declare module 'fastify' {
 }
 ```
 
-All auth configurations are made available with a `fastifyOauth2` prefix that's typed to `OAuth2Namespace | undefined`.
+All auth configurations are made available with an `oauth2` prefix that's typed to `OAuth2Namespace | undefined`, such as eg. `fastify.oauth2CustomOauth2` for `customOauth2`.
 
 ## Provider Quirks
 

--- a/index.js
+++ b/index.js
@@ -186,15 +186,18 @@ function fastifyOauth2 (fastify, options, next) {
     fastify.get(startRedirectPath, { schema }, startRedirectHandler)
   }
 
+  const decoration = {
+    oauth2,
+    getAccessTokenFromAuthorizationCodeFlow,
+    getNewAccessTokenUsingRefreshToken,
+    generateAuthorizationUri,
+    revokeToken,
+    revokeAllToken
+  }
+
   try {
-    fastify.decorate(name, {
-      oauth2,
-      getAccessTokenFromAuthorizationCodeFlow,
-      getNewAccessTokenUsingRefreshToken,
-      generateAuthorizationUri,
-      revokeToken,
-      revokeAllToken
-    })
+    fastify.decorate(name, decoration)
+    fastify.decorate(`fastifyOauth2${name.slice(0, 1).toUpperCase()}${name.slice(1)}`, decoration)
   } catch (e) {
     next(e)
     return

--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ function fastifyOauth2 (fastify, options, next) {
 
   try {
     fastify.decorate(name, decoration)
-    fastify.decorate(`fastifyOauth2${name.slice(0, 1).toUpperCase()}${name.slice(1)}`, decoration)
+    fastify.decorate(`oauth2${name.slice(0, 1).toUpperCase()}${name.slice(1)}`, decoration)
   } catch (e) {
     next(e)
     return

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -91,6 +91,9 @@ t.test('fastify-oauth2', t => {
     })
 
     fastify.get('/', function (request, reply) {
+      if (this.githubOAuth2 !== this.fastifyOauth2GithubOAuth2) {
+        throw new Error('Expected fastifyOauth2GithubOAuth2 to match githubOAuth2')
+      }
       this.githubOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, (err, result) => {
         if (err) throw err
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -91,8 +91,8 @@ t.test('fastify-oauth2', t => {
     })
 
     fastify.get('/', function (request, reply) {
-      if (this.githubOAuth2 !== this.fastifyOauth2GithubOAuth2) {
-        throw new Error('Expected fastifyOauth2GithubOAuth2 to match githubOAuth2')
+      if (this.githubOAuth2 !== this.oauth2GithubOAuth2) {
+        throw new Error('Expected oauth2GithubOAuth2 to match githubOAuth2')
       }
       this.githubOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, (err, result) => {
         if (err) throw err

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -160,3 +160,12 @@ declare namespace fastifyOauth2 {
 declare function fastifyOauth2(...params: Parameters<FastifyOauth2>): ReturnType<FastifyOauth2>
 
 export = fastifyOauth2
+
+type UpperCaseCharacters = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z';
+
+declare module 'fastify' {
+    interface FastifyInstance {
+        // UpperCaseCharacters ensures that the name has at least one character in it + is a simple camel-case:ification
+        [key: `fastifyOauth2${UpperCaseCharacters}${string}`]: fastifyOauth2.OAuth2Namespace | undefined;
+    }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -166,6 +166,6 @@ type UpperCaseCharacters = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' |
 declare module 'fastify' {
     interface FastifyInstance {
         // UpperCaseCharacters ensures that the name has at least one character in it + is a simple camel-case:ification
-        [key: `fastifyOauth2${UpperCaseCharacters}${string}`]: fastifyOauth2.OAuth2Namespace | undefined;
+        [key: `oauth2${UpperCaseCharacters}${string}`]: fastifyOauth2.OAuth2Namespace | undefined;
     }
 }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -104,6 +104,7 @@ expectAssignable<ProviderConfiguration>(fastifyOauth2.EPIC_GAMES_CONFIGURATION);
 
 server.get('/testOauth/callback', async (request, reply) => {
     expectType<OAuth2Namespace>(server.testOAuthName);
+    expectType<OAuth2Namespace | undefined>(server['fastifyOauth2TestOAuthName']);
 
     expectType<OAuth2Token>(await server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request));
     expectType<Promise<OAuth2Token>>(server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request));

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -104,7 +104,7 @@ expectAssignable<ProviderConfiguration>(fastifyOauth2.EPIC_GAMES_CONFIGURATION);
 
 server.get('/testOauth/callback', async (request, reply) => {
     expectType<OAuth2Namespace>(server.testOAuthName);
-    expectType<OAuth2Namespace | undefined>(server['fastifyOauth2TestOAuthName']);
+    expectType<OAuth2Namespace | undefined>(server.oauth2TestOAuthName);
 
     expectType<OAuth2Token>(await server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request));
     expectType<Promise<OAuth2Token>>(server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request));


### PR DESCRIPTION
This enables out of the box typing + can, if the old way is eventually dropped, stop the risk of clashes between other fastify plugins and/or core methods and the names used in auth configurations.

Typing is achieved thanks to:

```ts
type UpperCaseCharacters = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z';

declare module 'fastify' {
    interface FastifyInstance {
        // UpperCaseCharacters ensures that the name has at least one character in it + is a simple camel-case:ification
        [key: `fastifyOauth2${UpperCaseCharacters}${string}`]: fastifyOauth2.OAuth2Namespace | undefined;
    }
}
```

The `UpperCaseCharacters` is a trick from [`type-fest`](https://github.com/sindresorhus/type-fest/blob/98bb74d3cbb73a71ed325cd984a754118ba4d054/source/internal.d.ts#L49)'s camel case helpers (which I contributed the first version of) and is used in its simplest form here for two reasons:

1. It ensures that `this.fastifyOauth2` is not matched, something it would be with `fastifyOauth2${string}`
2. It makes it look somewhat prettier, making a name like `google` become `this.fastifyOauth2Google`

In this PR I have changed the docs to prefer the new prefixed properties, but I have kept the old decoration as well, to not break implementations for now.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
