### PR TITLE
Use `@types/simple-oauth2` instead of redoing it

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@fastify/cookie": "^9.0.4",
+    "@types/simple-oauth2": "^5.0.4",
     "fastify-plugin": "^4.5.1",
     "simple-oauth2": "^5.0.0"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
 import { CookieSerializeOptions } from "@fastify/cookie";
+import { ModuleOptions } from 'simple-oauth2';
 
 interface FastifyOauth2 extends FastifyPluginCallback<fastifyOauth2.FastifyOAuth2Options> {
     APPLE_CONFIGURATION: fastifyOauth2.ProviderConfiguration;
@@ -69,47 +70,14 @@ declare namespace fastifyOauth2 {
         revokeAll(): Promise<void>;
     }
 
-    export interface ProviderConfiguration {
-        /** String used to set the host to request the tokens to. Required. */
-        tokenHost: string;
-        /** String path to request an access token. Default to /oauth/token. */
-        tokenPath?: string | undefined;
-        /** String path to revoke an access token. Default to /oauth/revoke. */
-        revokePath?: string | undefined;
-        /** String used to set the host to request an "authorization code". Default to the value set on auth.tokenHost. */
-        authorizeHost?: string | undefined;
-        /** String path to request an authorization code. Default to /oauth/authorize. */
-        authorizePath?: string | undefined;
-    }
+    // Can't extend ModuleOptions["auth"] directly
+    type SimpleOauth2ProviderConfiguration = ModuleOptions["auth"];
+    // Kept for backwards compatibility
+    export interface ProviderConfiguration extends SimpleOauth2ProviderConfiguration {}
 
-    export interface Credentials {
-        client: {
-            /** Service registered client id. Required. */
-            id: string;
-            /** Service registered client secret. Required. */
-            secret: string;
-            /** Parameter name used to send the client secret. Default to client_secret. */
-            secretParamName?: string | undefined;
-            /** Parameter name used to send the client id. Default to client_id. */
-            idParamName?: string | undefined;
-        };
+    // Kept for backwards compatibility
+    export interface Credentials extends ModuleOptions<string> {
         auth: ProviderConfiguration;
-        /**
-         * Used to set global options to the internal http library (wreck).
-         * All options except baseUrl are allowed
-         * Defaults to header.Accept = "application/json"
-         */
-        http?: {} | undefined;
-        options?: {
-            /** Format of data sent in the request body. Defaults to form. */
-            bodyFormat?: "json" | "form" | undefined;
-            /**
-             * Indicates the method used to send the client.id/client.secret authorization params at the token request.
-             * If set to body, the bodyFormat option will be used to format the credentials.
-             * Defaults to header
-             */
-            authorizationMethod?: "header" | "body" | undefined;
-        } | undefined;
     }
 
     export interface OAuth2Namespace {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
-import { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
-import { CookieSerializeOptions } from "@fastify/cookie";
-import { ModuleOptions } from 'simple-oauth2';
+import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
+import type { CookieSerializeOptions } from "@fastify/cookie";
+import type { ModuleOptions } from 'simple-oauth2';
 
 interface FastifyOauth2 extends FastifyPluginCallback<fastifyOauth2.FastifyOAuth2Options> {
     APPLE_CONFIGURATION: fastifyOauth2.ProviderConfiguration;


### PR DESCRIPTION
Prior to https://github.com/fastify/fastify-oauth2/pull/172 the `Credentials` was typed to a much more slim subset of what `simple-oauth2` currently accepts, but in #172 (which contained #170 / #152) it was extended to pretty much be the full typing of `simple-oauth2`, but without actually referring to `@types/simple-oauth2`.

This PR adds `@types/simple-oauth2` and uses the types from that one instead – and does so in a backwards compatible way by keeping `ProviderConfiguration` and `Credentials`.

My personal motivation for this was that I wanted to add a HTTP Header to some requests (I want to add a `User-Agent` as I personally think that's good practice to do) and when I looked around if it was supported I realized that it was, but through the `Credentials['http']` that's currently typed as:

```ts
http?: {} | undefined;
```

[This is what it looks like](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/091544cc1a6cc86156761480156cae241e73853e/types/simple-oauth2/index.d.ts#L53-L79) in `@types/simple-oauth2`, much more complete:

```ts
http?: Omit<WreckHttpOptions, 'baseUrl' | 'headers' | 'redirects' | 'json'> & {
    baseUrl?: undefined;
    headers?: {
        /**
         * Acceptable http response content type. Defaults to application/json
         */
        accept?: string;
        /**
         * Always overriden by the library to properly send the required credentials on each scenario
         */
        authorization?: string;
        [key: string]: unknown
    } | undefined;
    /**
     * Number or redirects to follow. Defaults to false (no redirects)
     */
    redirects?: false | number | undefined;
    /**
     * JSON response parsing mode. Defaults to strict
     */
    json?: boolean | "strict" | "force" | undefined;
 } | undefined;
```

When looking through the git log, PR:s and issues I can't find any mentioning of why these types wasn't referred to instead of duplicating them. Maybe the `@types/simple-oauth2` wasn't available at the time, but now that they are I think its a good idea to refer to them.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
