### PR TITLE
Add default user-agent + enable custom one

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function fastifyOauth2 (fastify, options, next) {
   const generateCallbackUriParams = (credentials.auth && credentials.auth[kGenerateCallbackUriParams]) || defaultGenerateCallbackUriParams
   const cookieOpts = Object.assign({ httpOnly: true, sameSite: 'lax' }, options.cookie)
   const userAgent = options.userAgent
-    ? options.userAgent + ' ' + USER_AGENT
+    ? `${options.userAgent} ${USER_AGENT}`
     : USER_AGENT
 
   function generateAuthorizationUri (request, reply) {

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function fastifyOauth2 (fastify, options, next) {
   const cookieOpts = Object.assign({ httpOnly: true, sameSite: 'lax' }, options.cookie)
   const userAgent = options.userAgent
     ? `${options.userAgent} ${USER_AGENT}`
-    : USER_AGENT
+    : (options.userAgent === false ? undefined : USER_AGENT)
 
   function generateAuthorizationUri (request, reply) {
     const state = generateStateFunction(request)
@@ -198,7 +198,7 @@ function fastifyOauth2 (fastify, options, next) {
     http: {
       ...credentials.http,
       headers: {
-        'User-Agent': userAgent,
+        ...(userAgent ? { 'User-Agent': userAgent } : {}),
         ...credentials.http?.headers
       }
     }

--- a/index.js
+++ b/index.js
@@ -8,9 +8,7 @@ const kGenerateCallbackUriParams = Symbol.for('fastify-oauth2.generate-callback-
 
 const { promisify, callbackify } = require('util')
 
-const { homepage, version } = require('./package.json')
-
-const USER_AGENT = `fastify-oauth2/${version} (${homepage})`
+const USER_AGENT = 'fastify-oauth2'
 
 function defaultGenerateStateFunction () {
   return randomBytes(16).toString('base64url')

--- a/index.js
+++ b/index.js
@@ -92,15 +92,15 @@ function fastifyOauth2 (fastify, options, next) {
     schema = { tags }
   } = options
 
-  const userAgent = options.userAgent
-    ? `${options.userAgent} ${USER_AGENT}`
-    : (options.userAgent === false ? undefined : USER_AGENT)
+  const userAgent = options.userAgent === false
+    ? undefined
+    : (options.userAgent || USER_AGENT)
   const credentials = {
     ...options.credentials,
     http: {
       ...options.credentials.http,
       headers: {
-        ...(userAgent ? { 'User-Agent': userAgent } : {}),
+        'User-Agent': userAgent,
         ...options.credentials.http?.headers
       }
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "standard | snazzy",
     "lint:fix": "standard --fix",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:coverage": "npm run unit -- --cov --coverage-report=html",
+    "test:coverage": "npm run test:unit -- --cov --coverage-report=html",
     "test:typescript": "tsd",
     "test:unit": "tap"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,7 +8,7 @@ const fastifyOauth2 = require('..')
 
 nock.disableNetConnect()
 
-function makeRequests (t, fastify, userAgentRegexp) {
+function makeRequests (t, fastify, userAgentHeaderMatcher) {
   fastify.listen({ port: 0 }, function (err) {
     t.error(err)
 
@@ -40,7 +40,7 @@ function makeRequests (t, fastify, userAgentRegexp) {
 
       const githubScope = nock('https://github.com')
         .matchHeader('Authorization', 'Basic bXktY2xpZW50LWlkOm15LXNlY3JldA==')
-        .matchHeader('User-Agent', userAgentRegexp || 'fastify-oauth2')
+        .matchHeader('User-Agent', userAgentHeaderMatcher || 'fastify-oauth2')
         .post('/login/oauth/access_token', 'grant_type=authorization_code&code=my-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback')
         .reply(200, RESPONSE_BODY)
         .post('/login/oauth/access_token', 'grant_type=refresh_token&refresh_token=my-refresh-token')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -222,7 +222,7 @@ t.test('fastify-oauth2', t => {
 
     t.teardown(fastify.close.bind(fastify))
 
-    makeRequests(t, fastify, 'test/1.2.3 fastify-oauth2')
+    makeRequests(t, fastify, 'test/1.2.3')
   })
 
   t.test('overridden user-agent', t => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,7 +40,7 @@ function makeRequests (t, fastify, userAgentRegexp) {
 
       const githubScope = nock('https://github.com')
         .matchHeader('Authorization', 'Basic bXktY2xpZW50LWlkOm15LXNlY3JldA==')
-        .matchHeader('User-Agent', userAgentRegexp || /^fastify-oauth2\/[0-9.]+ \(http[^)]+\)$/)
+        .matchHeader('User-Agent', userAgentRegexp || 'fastify-oauth2')
         .post('/login/oauth/access_token', 'grant_type=authorization_code&code=my-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback')
         .reply(200, RESPONSE_BODY)
         .post('/login/oauth/access_token', 'grant_type=refresh_token&refresh_token=my-refresh-token')
@@ -222,7 +222,7 @@ t.test('fastify-oauth2', t => {
 
     t.teardown(fastify.close.bind(fastify))
 
-    makeRequests(t, fastify, /^test\/1\.2\.3 fastify-oauth2\/[0-9.]+ \(http[^)]+\)$/)
+    makeRequests(t, fastify, 'test/1.2.3 fastify-oauth2')
   })
 
   t.test('overridden user-agent', t => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -33,6 +33,7 @@ declare namespace fastifyOauth2 {
     tags?: string[];
     schema?: object;
     cookie?: CookieSerializeOptions;
+    userAgent?: string;
   }
 
     export type TToken = 'access_token' | 'refresh_token'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -33,7 +33,7 @@ declare namespace fastifyOauth2 {
     tags?: string[];
     schema?: object;
     cookie?: CookieSerializeOptions;
-    userAgent?: string;
+    userAgent?: string | false;
   }
 
     export type TToken = 'access_token' | 'refresh_token'


### PR DESCRIPTION
The [RFC9110 HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110#field.user-agent) spec says:

> A user agent **SHOULD** send a User-Agent header field in each request unless specifically configured not to do so.

So I think we should. 

~~Convention is that a library appends their user-agent to the one that's been set at the level above them, hence the user provided user-agent comes before the default one set in this module.~~

~~To provide context, the version number of this module + the home page of it is included in the User-Agent. That way an API can diagnose possibly faulty consumers and file an issue.~~

If someone wouldn't want to expose that info in a header, they can always set a custom User-Agent header directly in the http settings. Especially if #225 gets merged.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
