### PR TITLE
Test option compatibility with `@types/simple-oauth2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^20.5.3",
+    "@types/simple-oauth2": "^5.0.4",
     "fastify": "^4.21.0",
     "nock": "^13.3.3",
     "simple-get": "^4.0.1",

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -7,6 +7,7 @@ import fastifyOauth2, {
     OAuth2Token,
     ProviderConfiguration
 } from '..';
+import type { ModuleOptions } from 'simple-oauth2';
 
 /**
  * Preparing some data for testing.
@@ -15,6 +16,14 @@ const auth = fastifyOauth2.GOOGLE_CONFIGURATION;
 const scope = ['r_emailaddress', 'r_basicprofile'];
 const tags = ['oauth2', 'oauth'];
 const credentials: Credentials = {
+    client: {
+        id: 'test_id',
+        secret: 'test_secret',
+    },
+    auth: auth,
+};
+
+const simpleOauth2Options: ModuleOptions = {
     client: {
         id: 'test_id',
         secret: 'test_secret',
@@ -83,6 +92,13 @@ expectType<ProviderConfiguration>(auth);
 expectType<string[]>(scope);
 expectType<string[]>(tags);
 expectType<Credentials>(credentials);
+
+// Ensure duplicayed simple-oauth2 are compatible with simple-oauth2
+expectAssignable<ModuleOptions<string>>(credentials);
+expectAssignable<ModuleOptions["auth"]>(auth);
+// Ensure published types of simple-oauth2 are accepted
+expectAssignable<Credentials>(simpleOauth2Options);
+expectAssignable<ProviderConfiguration>(simpleOauth2Options.auth);
 
 expectError(fastifyOauth2()); // error because missing required arguments
 expectError(fastifyOauth2(server, {}, () => {


### PR DESCRIPTION
This is an alternative to #225 where rather than using `@types/simple-oauth2` in the published types we ensure at test time that the local types are indeed compatible with the published types of `@types/simple-oauth2`.

That way a consumer that wants to have access to the full types of `simple-oauth2` can add `@types/simple-oauth2` in their own project, knowing that it will be compatible

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
