### PR TITLE
feat: async `generateStateFunction` and `checkStateFunction`

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,38 @@ When you set it, it is required to provide the function `checkStateFunction` in 
   })
 ```
 
+Async functions are supported here, and the fastify instance can be accessed via `this`.
+
+```js
+  fastify.register(oauthPlugin, {
+    name: 'facebookOAuth2',
+    credentials: {
+      client: {
+        id: '<CLIENT_ID>',
+        secret: '<CLIENT_SECRET>'
+      },
+      auth: oauthPlugin.FACEBOOK_CONFIGURATION
+    },
+    // register a fastify url to start the redirect flow
+    startRedirectPath: '/login/facebook',
+    // facebook redirect here after the user login
+    callbackUri: 'http://localhost:3000/login/facebook/callback',
+    // custom function to generate the state and store it into the redis
+    generateStateFunction: async function (request) {
+      const state = request.query.customCode
+      await this.redis.set(stateKey, state)
+      return state
+    },
+    // custom function to check the state is valid
+    checkStateFunction: async function (request, callback) {
+      if (request.query.state !== request.session.state) {
+        throw new Error('Invalid state')
+      }
+      return true
+    }
+  })
+```
+
 ## Set custom callbackUri Parameters
 
 The `callbackUriParams` accepts an object that will be translated to query parameters for the callback OAUTH flow. The default value is {}.

--- a/README.md
+++ b/README.md
@@ -341,12 +341,13 @@ fastify.googleOAuth2.getNewAccessTokenUsingRefreshToken(currentAccessToken, (err
 });
 ```
 
-- `generateAuthorizationUri(requestObject, replyObject)`: A function that returns the authorization uri. This is generally useful when you want to handle the redirect yourself in a specific route. The `requestObject` argument passes the request object to the `generateStateFunction`). You **do not** need to declare a `startRedirectPath` if you use this approach. Example of how you would use it:
+- `generateAuthorizationUri(requestObject, replyObject, callback)`: A function that generates the authorization uri. If the callback is not passed this function will return a Promise. The string resulting from the callback call or the resolved Promise is the authorization uri. This is generally useful when you want to handle the redirect yourself in a specific route. The `requestObject` argument passes the request object to the `generateStateFunction`). You **do not** need to declare a `startRedirectPath` if you use this approach. Example of how you would use it:
 
 ```js
-fastify.get('/external', { /* Hooks can be used here */ }, async (req, reply) => {
-  const authorizationEndpoint = fastify.oauth2CustomOAuth2.generateAuthorizationUri(req, reply);
-  reply.redirect(authorizationEndpoint)
+fastify.get('/external', { /* Hooks can be used here */ }, (req, reply) => {
+  fastify.oauth2CustomOAuth2.generateAuthorizationUri(req, reply, (err, authorizationEndpoint) => {
+    reply.redirect(authorizationEndpoint)
+  });
 });
 ```
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
+import { FastifyPluginCallback, FastifyReply, FastifyRequest, FastifyInstance } from 'fastify';
 import { CookieSerializeOptions } from "@fastify/cookie";
 
 interface FastifyOauth2 extends FastifyPluginCallback<fastifyOauth2.FastifyOAuth2Options> {
@@ -20,6 +20,16 @@ interface FastifyOauth2 extends FastifyPluginCallback<fastifyOauth2.FastifyOAuth
 }
 
 declare namespace fastifyOauth2 {
+  export interface FastifyGenerateStateFunction {
+    (this: FastifyInstance, request: FastifyRequest): Promise<string> | string
+    (this: FastifyInstance, request: FastifyRequest, callback: (err: any, state: string) => void): void
+  }
+
+  export interface FastifyCheckStateFunction {
+    (this: FastifyInstance, request: FastifyRequest): Promise<boolean> | boolean
+    (this: FastifyInstance, request: FastifyRequest, callback: (err?: any) => void): void
+  }
+
   export interface FastifyOAuth2Options {
     name: string;
     scope?: string[];
@@ -27,8 +37,8 @@ declare namespace fastifyOauth2 {
     callbackUri: string;
     callbackUriParams?: Object;
     tokenRequestParams?: Object;
-    generateStateFunction?: Function;
-    checkStateFunction?: Function;
+    generateStateFunction?: FastifyGenerateStateFunction;
+    checkStateFunction?: FastifyCheckStateFunction;
     startRedirectPath?: string;
     tags?: string[];
     schema?: object;
@@ -148,7 +158,13 @@ declare namespace fastifyOauth2 {
         generateAuthorizationUri(
             request: FastifyRequest,
             reply: FastifyReply,
-        ): string;
+          callback: (err: any, uri: string) => void
+        ): void
+
+        generateAuthorizationUri(
+            request: FastifyRequest,
+            reply: FastifyReply,
+        ): Promise<string>;
 
         revokeToken(
             revokeToken: Token,

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -8,6 +8,7 @@ import fastifyOauth2, {
     ProviderConfiguration
 } from '..';
 import type { ModuleOptions } from 'simple-oauth2';
+import { FastifyInstance } from 'fastify';
 
 /**
  * Preparing some data for testing.
@@ -43,9 +44,13 @@ const OAuth2Options: FastifyOAuth2Options = {
     credentials: credentials,
     callbackUri: 'http://localhost/testOauth/callback',
     callbackUriParams: {},
-    generateStateFunction: () => {
+    generateStateFunction: function () {
+      expectType<FastifyInstance>(this)
+      return 'test'
     },
-    checkStateFunction: () => {
+    checkStateFunction: function () {
+      expectType<FastifyInstance>(this)
+      return true
     },
     startRedirectPath: '/login/testOauth',
     cookie: {
@@ -119,8 +124,7 @@ server.register(fastifyOauth2, {
     scope: scope,
     credentials: credentials,
     callbackUri: 'http://localhost/testOauth/callback',
-    checkStateFunction: () => {
-    },
+    checkStateFunction: () => true,
 })
 
 expectError(server.register(fastifyOauth2, {
@@ -128,8 +132,7 @@ expectError(server.register(fastifyOauth2, {
     scope: scope,
     credentials: credentials,
     callbackUri: 'http://localhost/testOauth/callback',
-    checkStateFunction: () => {
-    },
+    checkStateFunction: () => true,
     startRedirectPath: 2,
 }))
 
@@ -263,7 +266,8 @@ server.get('/testOauth/callback', async (request, reply) => {
         expectError<void>(server.testOAuthName.getNewAccessTokenUsingRefreshToken(token.token, {}))
     }
 
-    expectType<string>(server.testOAuthName.generateAuthorizationUri(request, reply));
+    expectType<Promise<string>>(server.testOAuthName.generateAuthorizationUri(request, reply));
+    expectType<void>(server.testOAuthName.generateAuthorizationUri(request, reply, (err) => {}))
     // error because missing reply argument
     expectError<string>(server.testOAuthName.generateAuthorizationUri(request));
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

`generateStateFunction` and `checkStateFunction` now support async function, fastify instance can be accessed via `this`.

And the `generateAuthorizationUri` now returns a `Promise<string>` due to `generateStateFunction` can be async, which might be a breaking change.

close #238 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Test results

```shell
❯ pnpm run test
> @fastify/oauth2@7.5.0 test
> npm run test:unit && npm run test:typescript


> @fastify/oauth2@7.5.0 test:unit
> tap

​ PASS ​ test/index.test.js 209 OK 292.476ms


                         
  🌈 SUMMARY RESULTS 🌈  
                         

Suites:   ​1 passed​, ​1 of 1 completed​
Asserts:  ​​​209 passed​, ​of 209​
​Time:​   ​622.737ms
​----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |      100 |     100 |     100 |                   
 index.js |     100 |      100 |     100 |     100 |                   
----------|---------|----------|---------|---------|-------------------

> @fastify/oauth2@7.5.0 test:typescript
> tsd

```