### PR TITLE
feat: implement PKCE extension for Authorization Code Grant (RFC 7636)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ This fastify plugin adds 5 utility decorators to your fastify instance using the
   - `refresh_token` (optional, only if the `offline scope` was originally requested, as seen in the callbackUriParams example)
   - `token_type` (generally `'Bearer'`)
   - `expires_in` (number of seconds for the token to expire, e.g. `240000`)
+
+- OR `getAccessTokenFromAuthorizationCodeFlow(request, reply, callback)` variant with 3 arguments, which should be used when PKCE extension is used.
+  This allows fastify-oauth2 to delete PKCE code_verifier cookie so it doesn't stay in browser in case server has issue when fetching token. See [Google With PKCE example for more](./examples/google-with-pkce.js).
+
 - `getNewAccessTokenUsingRefreshToken(Token, params, callback)`: A function that takes a `AccessToken`-Object as `Token` and retrieves a new `AccessToken`-Object. This is generally useful with background processing workers to re-issue a new AccessToken when the previous AccessToken has expired. The `params` argument is optional and it is an object that can be used to pass in additional parameters to the refresh request (e.g. a stricter set of scopes). If the callback is not passed this function will return a Promise. The object resulting from the callback call or the resolved Promise is a new `AccessToken` object (see above). Example of how you would use it for `name:googleOAuth2`:
 ```js
 fastify.googleOAuth2.getNewAccessTokenUsingRefreshToken(currentAccessToken, (err, newAccessToken) => {

--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ fastify.register(oauthPlugin, {
     // custom query param that will be passed to callbackUri
     access_type: 'offline', // will tell Google to send a refreshToken too
   },
+  pkce: 'S256'
+  // check if your provider supports PKCE, 
+  // in case they do, 
+  // use of this parameter is highly encouraged 
+  // in order to prevent authorization code interception attacks
 });
 ```
 
@@ -255,6 +260,10 @@ This fastify plugin adds 5 utility decorators to your fastify instance using the
 
 - OR `getAccessTokenFromAuthorizationCodeFlow(request, reply, callback)` variant with 3 arguments, which should be used when PKCE extension is used.
   This allows fastify-oauth2 to delete PKCE code_verifier cookie so it doesn't stay in browser in case server has issue when fetching token. See [Google With PKCE example for more](./examples/google-with-pkce.js).
+  
+  *Important to note*: if your provider supports `S256` as code_challenge_method, always prefer that. 
+  Only use `plain` when your provider doesn't support `S256`.
+
 
 - `getNewAccessTokenUsingRefreshToken(Token, params, callback)`: A function that takes a `AccessToken`-Object as `Token` and retrieves a new `AccessToken`-Object. This is generally useful with background processing workers to re-issue a new AccessToken when the previous AccessToken has expired. The `params` argument is optional and it is an object that can be used to pass in additional parameters to the refresh request (e.g. a stricter set of scopes). If the callback is not passed this function will return a Promise. The object resulting from the callback call or the resolved Promise is a new `AccessToken` object (see above). Example of how you would use it for `name:googleOAuth2`:
 ```js

--- a/examples/google-with-pkce.js
+++ b/examples/google-with-pkce.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const fastify = require('fastify')({ logger: { level: 'trace' } })
+const sget = require('simple-get')
+
+const cookieOpts = {
+  // domain: 'localhost',
+  path: '/',
+  secure: true,
+  sameSite: 'lax',
+  httpOnly: true
+}
+
+// const oauthPlugin = require('fastify-oauth2')
+fastify.register(require('@fastify/cookie'), {
+  secret: ['my-secret'],
+  parseOptions: cookieOpts
+})
+
+const oauthPlugin = require('..')
+fastify.register(oauthPlugin, {
+  name: 'googleOAuth2',
+  scope: ['openid', 'profile', 'email'],
+  credentials: {
+    client: {
+      id: process.env.CLIENT_ID,
+      secret: process.env.CLIENT_SECRET
+    },
+    auth: oauthPlugin.GOOGLE_CONFIGURATION
+  },
+  startRedirectPath: '/login/google',
+  callbackUri: 'http://localhost:3000/interaction/callback/google',
+  cookie: cookieOpts,
+  pkce: 'S256' // "plain" is also supported in this library, see your own provider's .well-known/openid-configuration endpoint (if it's exposed) to understand which methods are supported
+})
+
+fastify.get('/interaction/callback/google', function (request, reply) {
+  // Note that in this example a "reply" is also passed, it's so that code verifier cookie can be cleaned before
+  // token is requested from token endpoint
+  this.googleOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, reply, (err, result) => {
+    if (err) {
+      reply.send(err)
+      return
+    }
+
+    sget.concat({
+      url: 'https://www.googleapis.com/oauth2/v2/userinfo',
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer ' + result.token.access_token
+      },
+      json: true
+    }, function (err, res, data) {
+      if (err) {
+        reply.send(err)
+        return
+      }
+      reply.send(data)
+    })
+  })
+})
+
+fastify.listen({ port: 3000 })
+fastify.log.info('go to http://localhost:3000/login/google')

--- a/examples/google-with-pkce.js
+++ b/examples/google-with-pkce.js
@@ -31,7 +31,27 @@ fastify.register(oauthPlugin, {
   startRedirectPath: '/login/google',
   callbackUri: 'http://localhost:3000/interaction/callback/google',
   cookie: cookieOpts,
-  pkce: 'S256' // "plain" is also supported in this library, see your own provider's .well-known/openid-configuration endpoint (if it's exposed) to understand which methods are supported
+  pkce: 'S256'
+  /* use S256:
+
+  Most modern providers (authorization servers) that are up to date with standards,
+  will support S256 and also announce that in discovery endpoint (.well-known/openid-configuration):
+  ...
+  "code_challenge_methods_supported": [
+    "S256",
+    "plain"
+  ]
+  ...
+
+  "plain" is also supported in this library but it's use is discouraged.
+  Only do it in case that you use some legacy provider (authorization server),
+  and you see provider's .well-known/openid-configuration
+  endpoint has only that single challenge method:
+  ...
+  "code_challenge_methods_supported": [
+    "plain"
+  ]
+  */
 })
 
 fastify.get('/interaction/callback/google', function (request, reply) {

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function fastifyOauth2 (fastify, options, next) {
     return next(new Error('options.userAgent should be a string'))
   }
   if (options.pkce && (typeof options.pkce !== 'string' || !PKCE_METHODS.includes(options.pkce))) {
-    return next(new Error('options.pkce should be one of "plain" | "S256" when used'))
+    return next(new Error('options.pkce should be one of "S256" | "plain" when used'))
   }
   if (!fastify.hasReplyDecorator('cookie')) {
     fastify.register(require('@fastify/cookie'))

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { randomBytes } = require('node:crypto')
+const { randomBytes, createHash } = require('node:crypto')
 
 const fp = require('fastify-plugin')
 const { AuthorizationCode } = require('simple-oauth2')
@@ -9,9 +9,18 @@ const kGenerateCallbackUriParams = Symbol.for('fastify-oauth2.generate-callback-
 const { promisify, callbackify } = require('node:util')
 
 const USER_AGENT = 'fastify-oauth2'
+const VERIFIER_COOKIE_NAME = 'oauth2-code-verifier'
+const S256 = 'S256'
+const PKCE_METHODS = ['plain', S256]
+
+const b64Encode = (input, encoding = 'utf8') => Buffer.from(input, encoding).toString('base64url')
+
+const random = (bytes = 32) => b64Encode(randomBytes(bytes))
+const codeVerifier = random
+const codeChallenge = verifier => b64Encode(createHash('sha256').update(verifier).digest())
 
 function defaultGenerateStateFunction () {
-  return randomBytes(16).toString('base64url')
+  return random(16).toString('base64url')
 }
 
 function defaultCheckStateFunction (request, callback) {
@@ -74,7 +83,9 @@ function fastifyOauth2 (fastify, options, next) {
   if (options.userAgent && typeof options.userAgent !== 'string') {
     return next(new Error('options.userAgent should be a string'))
   }
-
+  if (options.pkce && (typeof options.pkce !== 'string' || !PKCE_METHODS.includes(options.pkce))) {
+    return next(new Error('options.pkce should be one of "plain" | "S256" when used'))
+  }
   if (!fastify.hasReplyDecorator('cookie')) {
     fastify.register(require('@fastify/cookie'))
   }
@@ -89,7 +100,8 @@ function fastifyOauth2 (fastify, options, next) {
     checkStateFunction = defaultCheckStateFunction,
     startRedirectPath,
     tags = [],
-    schema = { tags }
+    schema = { tags },
+    pkce
   } = options
 
   const userAgent = options.userAgent === false
@@ -113,11 +125,23 @@ function fastifyOauth2 (fastify, options, next) {
 
     reply.setCookie('oauth2-redirect-state', state, cookieOpts)
 
+    // when PKCE extension is used
+    let pkceParams = {}
+    if (pkce) {
+      const verifier = codeVerifier()
+      const challenge = pkce === S256 ? codeChallenge(verifier) : verifier
+      pkceParams = {
+        code_challenge: challenge,
+        code_challenge_method: pkce
+      }
+      reply.setCookie(VERIFIER_COOKIE_NAME, verifier, cookieOpts)
+    }
+
     const urlOptions = Object.assign({}, generateCallbackUriParams(callbackUriParams, request, scope, state), {
       redirect_uri: callbackUri,
       scope,
       state
-    })
+    }, pkceParams)
 
     return oauth2.authorizeURL(urlOptions)
   }
@@ -128,34 +152,44 @@ function fastifyOauth2 (fastify, options, next) {
     reply.redirect(authorizationUri)
   }
 
-  const cbk = function (o, code, callback) {
+  const cbk = function (o, code, pkceParams, callback) {
     const body = Object.assign({}, tokenRequestParams, {
       code,
       redirect_uri: callbackUri
-    })
+    }, pkceParams)
 
     return callbackify(o.oauth2.getToken.bind(o.oauth2, body))(callback)
   }
 
-  function getAccessTokenFromAuthorizationCodeFlowCallbacked (request, callback) {
+  function getAccessTokenFromAuthorizationCodeFlowCallbacked (request, reply, callback) {
     const code = request.query.code
+    const pkceParams = pkce ? { code_verifier: request.cookies['oauth2-code-verifier'] } : {}
+
+    const _callback = typeof reply === 'function' ? reply : callback
+
+    if (reply && typeof reply !== 'function') {
+      // cleanup a cookie if plugin user uses (req, res, cb) signature variant of getAccessToken fn
+      clearCodeVerifierCookie(reply)
+    }
 
     checkStateFunction(request, function (err) {
       if (err) {
         callback(err)
         return
       }
-      cbk(fastify[name], code, callback)
+      cbk(fastify[name], code, pkceParams, _callback)
     })
   }
 
   const getAccessTokenFromAuthorizationCodeFlowPromisified = promisify(getAccessTokenFromAuthorizationCodeFlowCallbacked)
 
-  function getAccessTokenFromAuthorizationCodeFlow (request, callback) {
-    if (!callback) {
-      return getAccessTokenFromAuthorizationCodeFlowPromisified(request)
+  function getAccessTokenFromAuthorizationCodeFlow (request, reply, callback) {
+    const _callback = typeof reply === 'function' ? reply : callback
+
+    if (!_callback) {
+      return getAccessTokenFromAuthorizationCodeFlowPromisified(request, reply)
     }
-    getAccessTokenFromAuthorizationCodeFlowCallbacked(request, callback)
+    getAccessTokenFromAuthorizationCodeFlowCallbacked(request, reply, _callback)
   }
 
   function getNewAccessTokenUsingRefreshTokenCallbacked (refreshToken, params, callback) {
@@ -198,6 +232,10 @@ function fastifyOauth2 (fastify, options, next) {
       return revokeAllTokenPromisified(token, params)
     }
     revokeAllTokenCallbacked(token, params, callback)
+  }
+
+  function clearCodeVerifierCookie (reply) {
+    reply.clearCookie(VERIFIER_COOKIE_NAME, cookieOpts)
   }
 
   const oauth2 = new AuthorizationCode(credentials)

--- a/index.js
+++ b/index.js
@@ -10,14 +10,11 @@ const { promisify, callbackify } = require('node:util')
 
 const USER_AGENT = 'fastify-oauth2'
 const VERIFIER_COOKIE_NAME = 'oauth2-code-verifier'
-const S256 = 'S256'
-const PKCE_METHODS = ['plain', S256]
+const PKCE_METHODS = ['S256', 'plain']
 
-const b64Encode = (input, encoding = 'utf8') => Buffer.from(input, encoding).toString('base64url')
-
-const random = (bytes = 32) => b64Encode(randomBytes(bytes))
+const random = (bytes = 32) => randomBytes(bytes).toString('base64url')
 const codeVerifier = random
-const codeChallenge = verifier => b64Encode(createHash('sha256').update(verifier).digest())
+const codeChallenge = verifier => createHash('sha256').update(verifier).digest('base64url')
 
 function defaultGenerateStateFunction () {
   return random(16)
@@ -129,7 +126,7 @@ function fastifyOauth2 (fastify, options, next) {
     let pkceParams = {}
     if (pkce) {
       const verifier = codeVerifier()
-      const challenge = pkce === S256 ? codeChallenge(verifier) : verifier
+      const challenge = pkce === 'S256' ? codeChallenge(verifier) : verifier
       pkceParams = {
         code_challenge: challenge,
         code_challenge_method: pkce

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const codeVerifier = random
 const codeChallenge = verifier => b64Encode(createHash('sha256').update(verifier).digest())
 
 function defaultGenerateStateFunction () {
-  return random(16).toString('base64url')
+  return random(16)
 }
 
 function defaultCheckStateFunction (request, callback) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -867,7 +867,7 @@ t.test('options.pkce', t => {
     pkce: {}
   })
     .ready(err => {
-      t.strictSame(err.message, 'options.pkce should be one of "plain" | "S256" when used')
+      t.strictSame(err.message, 'options.pkce should be one of "S256" | "plain" when used')
     })
 })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,7 +8,7 @@ const fastifyOauth2 = require('..')
 
 nock.disableNetConnect()
 
-function makeRequests (t, fastify, userAgentHeaderMatcher) {
+function makeRequests (t, fastify, userAgentHeaderMatcher, pkce) {
   fastify.listen({ port: 0 }, function (err) {
     t.error(err)
 
@@ -19,10 +19,15 @@ function makeRequests (t, fastify, userAgentHeaderMatcher) {
       t.error(err)
 
       t.equal(responseStart.statusCode, 302)
-      const matched = responseStart.headers.location.match(/https:\/\/github\.com\/login\/oauth\/authorize\?response_type=code&client_id=my-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=notifications&state=(.*)/)
-      t.ok(matched)
-      const state = matched[1]
+
+      const { searchParams } = new URL(responseStart.headers.location)
+      const [state, codeChallengeMethod, codeChallenge] = ['state', 'code_challenge_method', 'code_challenge'].map(k => searchParams.get(k))
+
       t.ok(state)
+      if (pkce) {
+        t.strictSame(codeChallengeMethod, pkce, 'pkce method must match')
+        t.ok(codeChallenge, 'code challenge is present')
+      }
 
       const RESPONSE_BODY = {
         access_token: 'my-access-token',
@@ -41,7 +46,7 @@ function makeRequests (t, fastify, userAgentHeaderMatcher) {
       const githubScope = nock('https://github.com')
         .matchHeader('Authorization', 'Basic bXktY2xpZW50LWlkOm15LXNlY3JldA==')
         .matchHeader('User-Agent', userAgentHeaderMatcher || 'fastify-oauth2')
-        .post('/login/oauth/access_token', 'grant_type=authorization_code&code=my-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback')
+        .post('/login/oauth/access_token', 'grant_type=authorization_code&code=my-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback' + (pkce ? '&code_verifier=myverifier' : ''))
         .reply(200, RESPONSE_BODY)
         .post('/login/oauth/access_token', 'grant_type=refresh_token&refresh_token=my-refresh-token')
         .reply(200, RESPONSE_BODY_REFRESHED)
@@ -50,7 +55,8 @@ function makeRequests (t, fastify, userAgentHeaderMatcher) {
         method: 'GET',
         url: '/?code=my-code&state=' + state,
         cookies: {
-          'oauth2-redirect-state': state
+          'oauth2-redirect-state': state,
+          'oauth2-code-verifier': pkce ? 'myverifier' : undefined
         }
       }, function (err, responseEnd) {
         t.error(err)
@@ -309,6 +315,84 @@ t.test('fastify-oauth2', t => {
     t.teardown(fastify.close.bind(fastify))
 
     makeRequests(t, fastify, userAgent => userAgent === undefined)
+  })
+
+  t.test('pkce.plain', t => {
+    const fastify = createFastify({ logger: { level: 'silent' } })
+
+    fastify.register(fastifyOauth2, {
+      name: 'githubOAuth2',
+      credentials: {
+        client: {
+          id: 'my-client-id',
+          secret: 'my-secret'
+        },
+        auth: fastifyOauth2.GITHUB_CONFIGURATION
+      },
+      startRedirectPath: '/login/github',
+      callbackUri: 'http://localhost:3000/callback',
+      scope: ['notifications'],
+      pkce: 'plain'
+    })
+
+    fastify.get('/', function (request, reply) {
+      return this.githubOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, reply)
+        .then(result => {
+          // attempts to refresh the token
+          return this.githubOAuth2.getNewAccessTokenUsingRefreshToken(result.token)
+        })
+        .then(token => {
+          return {
+            access_token: token.token.access_token,
+            refresh_token: token.token.refresh_token,
+            expires_in: token.token.expires_in,
+            token_type: token.token.token_type
+          }
+        })
+    })
+
+    t.teardown(fastify.close.bind(fastify))
+
+    makeRequests(t, fastify, undefined, 'plain')
+  })
+
+  t.test('pkce.S256', t => {
+    const fastify = createFastify({ logger: { level: 'silent' } })
+
+    fastify.register(fastifyOauth2, {
+      name: 'githubOAuth2',
+      credentials: {
+        client: {
+          id: 'my-client-id',
+          secret: 'my-secret'
+        },
+        auth: fastifyOauth2.GITHUB_CONFIGURATION
+      },
+      startRedirectPath: '/login/github',
+      callbackUri: 'http://localhost:3000/callback',
+      scope: ['notifications'],
+      pkce: 'S256'
+    })
+
+    fastify.get('/', function (request, reply) {
+      return this.githubOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, reply)
+        .then(result => {
+          // attempts to refresh the token
+          return this.githubOAuth2.getNewAccessTokenUsingRefreshToken(result.token)
+        })
+        .then(token => {
+          return {
+            access_token: token.token.access_token,
+            refresh_token: token.token.refresh_token,
+            expires_in: token.token.expires_in,
+            token_type: token.token.token_type
+          }
+        })
+    })
+
+    t.teardown(fastify.close.bind(fastify))
+
+    makeRequests(t, fastify, undefined, 'S256')
   })
 
   t.end()
@@ -762,6 +846,28 @@ t.test('options.userAgent should be a string', t => {
   })
     .ready(err => {
       t.strictSame(err.message, 'options.userAgent should be a string')
+    })
+})
+
+t.test('options.pkce', t => {
+  t.plan(1)
+
+  const fastify = createFastify({ logger: { level: 'silent' } })
+
+  fastify.register(fastifyOauth2, {
+    name: 'the-name',
+    credentials: {
+      client: {
+        id: 'my-client-id',
+        secret: 'my-secret'
+      },
+      auth: fastifyOauth2.GITHUB_CONFIGURATION
+    },
+    callbackUri: '/callback',
+    pkce: {}
+  })
+    .ready(err => {
+      t.strictSame(err.message, 'options.pkce should be one of "plain" | "S256" when used')
     })
 })
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,6 +34,7 @@ declare namespace fastifyOauth2 {
     schema?: object;
     cookie?: CookieSerializeOptions;
     userAgent?: string | false;
+    pkce?: 'plain' | 'S256';
   }
 
     export type TToken = 'access_token' | 'refresh_token'
@@ -121,6 +122,17 @@ declare namespace fastifyOauth2 {
 
         getAccessTokenFromAuthorizationCodeFlow(
             request: FastifyRequest,
+            reply: FastifyReply,
+        ): Promise<OAuth2Token>;
+
+        getAccessTokenFromAuthorizationCodeFlow(
+            request: FastifyRequest,
+            callback: (err: any, token: OAuth2Token) => void,
+        ): void;
+
+        getAccessTokenFromAuthorizationCodeFlow(
+            request: FastifyRequest,
+            reply: FastifyReply,
             callback: (err: any, token: OAuth2Token) => void,
         ): void;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,7 +34,7 @@ declare namespace fastifyOauth2 {
     schema?: object;
     cookie?: CookieSerializeOptions;
     userAgent?: string | false;
-    pkce?: 'plain' | 'S256';
+    pkce?: 'S256' | 'plain';
   }
 
     export type TToken = 'access_token' | 'refresh_token'

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify';
-import {expectAssignable, expectError, expectType} from 'tsd';
+import {expectAssignable, expectError, expectNotAssignable, expectType} from 'tsd';
 import fastifyOauth2, {
     FastifyOAuth2Options,
     Credentials,
@@ -51,8 +51,44 @@ const OAuth2Options: FastifyOAuth2Options = {
     cookie: {
         secure: true,
         sameSite: 'none'
-    }
+    },
 };
+
+
+expectAssignable<FastifyOAuth2Options>({
+    name: 'testOAuthName',
+    scope: scope,
+    credentials: credentials,
+    callbackUri: 'http://localhost/testOauth/callback',
+    callbackUriParams: {},
+    startRedirectPath: '/login/testOauth',
+    pkce: 'S256'
+})
+
+
+expectAssignable<FastifyOAuth2Options>({
+    name: 'testOAuthName',
+    scope: scope,
+    credentials: credentials,
+    callbackUri: 'http://localhost/testOauth/callback',
+    callbackUriParams: {},
+    startRedirectPath: '/login/testOauth',
+    pkce: 'plain'
+})
+
+expectNotAssignable<FastifyOAuth2Options>({
+    name: 'testOAuthName',
+    scope: scope,
+    credentials: credentials,
+    callbackUri: 'http://localhost/testOauth/callback',
+    callbackUriParams: {},
+    generateStateFunction: () => {
+    },
+    checkStateFunction: () => {
+    },
+    startRedirectPath: '/login/testOauth',
+    pkce: 'SOMETHING'
+})
 
 const server = fastify();
 
@@ -125,8 +161,15 @@ server.get('/testOauth/callback', async (request, reply) => {
 
     expectType<OAuth2Token>(await server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request));
     expectType<Promise<OAuth2Token>>(server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request));
+
+    expectType<OAuth2Token>(await server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request, reply));
+    expectType<Promise<OAuth2Token>>(server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request, reply));
     expectType<void>(
         server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request, (err: any, t: OAuth2Token): void => {
+        }),
+    );
+    expectType<void>(
+        server.testOAuthName.getAccessTokenFromAuthorizationCodeFlow(request, reply, (err: any, t: OAuth2Token): void => {
         }),
     );
     // error because Promise should not return void


### PR DESCRIPTION
See protocol details here:
https://www.rfc-editor.org/rfc/rfc7636.html

Closes #171 

So, actually `simple-oauth2` is not prohibitive in any way to have implementation of PKCE on top of it's Authorization Code Grant. 
They simply pass trough all the parameters down to authorization endpoint which are defined in their options.

So, I have implemented PKCE extension here... just because `fastify-cookie` is already present and used so we have a way to store the `code_verifier` somewhere, and then send it back to token endpoint.

I've added a variant for a getAccessToken function that supports passing down a `reply`  so `code_verifier` cookie is removed before hitting token endpoint at provider. 
It's good to clean up behind yourself ;)

Both versions are supported, `plain` and `S256`.

See video bellow (and don't care about my client secret, already rotated :))

In the video you can see also a curl hitting this endpoint and differences between S256 and plain.


https://github.com/fastify/fastify-oauth2/assets/11753867/7e469fb8-6e68-4f21-ad28-9d4952efad1c



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
