### PR TITLE
Feature: OpenID Connect Discovery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,47 @@ fastify.register(oauthPlugin, {
 })
 ```
 
+## Use automated discovery endpoint
+
+When your provider supports OpenID connect discovery and you want to configure authorization, token and revocation endpoints automatically, 
+then you can use discovery option.
+`discovery` is a simple object that requires `issuer` property.
+
+Issuer is expected to be string URL or metadata url.
+Variants with or without trailing slash are supported.
+
+You can see more in [example here](./examples/discovery.js).
+
+```js
+fastify.register(oauthPlugin, {
+  name: 'customOAuth2',
+  scope: ['profile', 'email'],
+  credentials: {
+    client: {
+      id: '<CLIENT_ID>',
+      secret: '<CLIENT_SECRET>',
+    },
+    // auth: oauthPlugin.GOOGLE_CONFIGURATION, THIS is not needed anymore when discovery is used.
+  },
+  startRedirectPath: '/login',
+  callbackUri: 'http://localhost:3000/callback',
+  callbackUriParams: {
+    // custom query param that will be passed to callbackUri
+    access_type: 'offline', // will tell Google to send a refreshToken too
+  },
+  discovery: { issuer: 'https://identity.mycustomdomain.com' }
+  // pkce: 'S256', you can still do this explicitly, but since discovery is used,
+  // it's BEST to let plugin do it itself 
+  // based on what Authorization Server Metadata response
+});
+```
+
+Important notes for discovery:
+
+- You should not set up `credentials.auth` anymore when discovery mechanics is used.
+- When your provider supports it, plugin will also select appropriate PKCE method in authorization code grant
+- In case you still want to select method yourself, and know exactly what you are doing; you can still do it explicitly.
+
 ### Schema configuration
 
 You can specify your own schema for the `startRedirectPath` end-point. It allows you to create a well-documented document when using `@fastify/swagger` together.

--- a/README.md
+++ b/README.md
@@ -140,14 +140,10 @@ fastify.register(oauthPlugin, {
       id: '<CLIENT_ID>',
       secret: '<CLIENT_SECRET>',
     },
-    // auth: oauthPlugin.GOOGLE_CONFIGURATION, THIS is not needed anymore when discovery is used.
+    // Note how "auth" is not needed anymore when discovery is used.
   },
   startRedirectPath: '/login',
   callbackUri: 'http://localhost:3000/callback',
-  callbackUriParams: {
-    // custom query param that will be passed to callbackUri
-    access_type: 'offline', // will tell Google to send a refreshToken too
-  },
   discovery: { issuer: 'https://identity.mycustomdomain.com' }
   // pkce: 'S256', you can still do this explicitly, but since discovery is used,
   // it's BEST to let plugin do it itself 

--- a/examples/discovery.js
+++ b/examples/discovery.js
@@ -37,10 +37,8 @@ fastify.register(oauthPlugin, {
   discovery: {
     /*
     When OIDC provider is mounted at root:
-    with trailing slash
+    with trailing slash (99% of the cases)
     - 'https://accounts.google.com/'
-
-    99% of the cases
     */
     issuer: 'https://accounts.google.com'
     /*

--- a/examples/discovery.js
+++ b/examples/discovery.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const fastify = require('fastify')({ logger: { level: 'trace' } })
+const sget = require('simple-get')
+
+const cookieOpts = {
+  // domain: 'localhost',
+  path: '/',
+  secure: true,
+  sameSite: 'lax',
+  httpOnly: true
+}
+
+// const oauthPlugin = require('fastify-oauth2')
+fastify.register(require('@fastify/cookie'), {
+  secret: ['my-secret'],
+  parseOptions: cookieOpts
+})
+
+const oauthPlugin = require('..')
+fastify.register(oauthPlugin, {
+  name: 'googleOAuth2',
+  // when provided, this userAgent will also be used at discovery endpoint
+  // to fully omit for whatever reason, set it to false
+  userAgent: 'my custom app (v1.0.0)',
+  scope: ['openid', 'profile', 'email'],
+  credentials: {
+    client: {
+      id: process.env.CLIENT_ID,
+      secret: process.env.CLIENT_SECRET
+    }
+  },
+  startRedirectPath: '/login/google',
+  callbackUri: 'http://localhost:3000/interaction/callback/google',
+  cookie: cookieOpts,
+  // pkce: 'S256' let discovery handle it itself
+  discovery: {
+    /*
+    When OIDC provider is mounted at root:
+    with trailing slash
+    - 'https://accounts.google.com/'
+
+    99% of the cases
+    */
+    issuer: 'https://accounts.google.com'
+    /*
+    also these variants work:
+    When OIDC provider is mounted at root:
+    with trailing slash
+    - 'https://accounts.google.com/'
+
+    When given explicit metadata endpoint:
+    - issuer: 'https://accounts.google.com/.well-known/openid-configuration'
+
+    When OIDC provider is nested at some route:
+     - with trailing slash
+    'https://id.mycustomdomain.com/nested/'
+    - without trailing slash
+    'https://id.mycustomdomain.com/nested'
+    */
+  }
+})
+
+fastify.get('/interaction/callback/google', function (request, reply) {
+  // Note that in this example a "reply" is also passed, it's so that code verifier cookie can be cleaned before
+  // token is requested from token endpoint
+  this.googleOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, reply, (err, result) => {
+    if (err) {
+      reply.send(err)
+      return
+    }
+
+    sget.concat({
+      url: 'https://www.googleapis.com/oauth2/v2/userinfo',
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer ' + result.token.access_token
+      },
+      json: true
+    }, function (err, res, data) {
+      if (err) {
+        reply.send(err)
+        return
+      }
+      reply.send(data)
+    })
+  })
+})
+
+fastify.listen({ port: 3000 })
+fastify.log.info('go to http://localhost:3000/login/google')

--- a/index.js
+++ b/index.js
@@ -291,11 +291,7 @@ function fastifyOauth2 (fastify, options, next) {
       // even with usage of discovery
       if (!options.pkce) {
         // otherwise select optimal pkce method for them,
-        // if such can be found in metadata response, ofcourse
-        const optimalPkceMethod = selectPkceFromMetadata(fetchedMetadata)
-        if (optimalPkceMethod) {
-          discoveredOptions.pkce = optimalPkceMethod
-        }
+        discoveredOptions.pkce = selectPkceFromMetadata(fetchedMetadata)
       }
       configure(discoveredOptions)
       next()
@@ -357,13 +353,11 @@ function getDiscoveryUri (issuer) {
 }
 
 function selectPkceFromMetadata (metadata) {
-  const methodsSupported = metadata.code_challenge_methods_supported || []
-  if (methodsSupported.includes('S256')) {
-    return 'S256'
-  } else if (methodsSupported.includes('plain')) {
+  const methodsSupported = metadata.code_challenge_methods_supported
+  if (methodsSupported && methodsSupported.length === 1 && methodsSupported.includes('plain')) {
     return 'plain'
   }
-  return null
+  return 'S256'
 }
 
 function getAuthFromMetadata (metadata) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,7 +30,7 @@ function makeRequests (t, fastify, userAgentHeaderMatcher, pkce, discoveryHost, 
 
   fastify.listen({ port: 0 }, function (err) {
     if (discoveryHostOptions.badJSON) {
-      t.equal(err.message, 'Unexpected token \'#\', "####$$%" is not valid JSON')
+      t.ok(err.message.startsWith('Unexpected token'))
       discoveryScope?.done()
       t.end()
       return

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -711,7 +711,7 @@ t.test('fastify-oauth2', t => {
     makeRequests(t, fastify, userAgent => userAgent === undefined, undefined, 'http://github.com')
   })
 
-  t.test('discovery - failed gracefully when discovery host errs with ETIMEDOUT or similar', t => {
+  t.test('discovery - failed gracefully when discovery host gives bad data', t => {
     const fastify = createFastify({ logger: { level: 'silent' } })
 
     fastify.register(fastifyOauth2, {
@@ -751,7 +751,7 @@ t.test('fastify-oauth2', t => {
     makeRequests(t, fastify, undefined, undefined, 'http://github.com', undefined, { badJSON: true })
   })
 
-  t.test('discovery - failed gracefully when discovery host gives bad data', t => {
+  t.test('discovery - failed gracefully when discovery host errs with ETIMEDOUT or similar', t => {
     const fastify = createFastify({ logger: { level: 'silent' } })
 
     fastify.register(fastifyOauth2, {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -587,7 +587,7 @@ t.test('fastify-oauth2', t => {
 
     t.teardown(fastify.close.bind(fastify))
 
-    makeRequests(t, fastify, undefined, undefined, 'https://github.com')
+    makeRequests(t, fastify, undefined, 'S256', 'https://github.com')
   })
 
   t.test('discovery with S256 - automatic, supported deep mount without a trailing slash', t => {
@@ -627,7 +627,7 @@ t.test('fastify-oauth2', t => {
 
     t.teardown(fastify.close.bind(fastify))
 
-    makeRequests(t, fastify, undefined, undefined, 'https://github.com/deepmount') // no trailin slash
+    makeRequests(t, fastify, undefined, 'S256', 'https://github.com/deepmount') // no trailin slash
   })
 
   t.test('discovery - supports HTTP', t => {
@@ -667,7 +667,7 @@ t.test('fastify-oauth2', t => {
 
     t.teardown(fastify.close.bind(fastify))
 
-    makeRequests(t, fastify, undefined, undefined, 'http://github.com')
+    makeRequests(t, fastify, undefined, 'S256', 'http://github.com')
   })
 
   t.test('discovery - supports omitting user agent', t => {
@@ -708,7 +708,7 @@ t.test('fastify-oauth2', t => {
 
     t.teardown(fastify.close.bind(fastify))
 
-    makeRequests(t, fastify, userAgent => userAgent === undefined, undefined, 'http://github.com')
+    makeRequests(t, fastify, userAgent => userAgent === undefined, 'S256', 'http://github.com')
   })
 
   t.test('discovery - failed gracefully when discovery host gives bad data', t => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,6 +35,7 @@ declare namespace fastifyOauth2 {
     cookie?: CookieSerializeOptions;
     userAgent?: string | false;
     pkce?: 'S256' | 'plain';
+    discovery?: { issuer: string; }
   }
 
     export type TToken = 'access_token' | 'refresh_token'

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -54,7 +54,6 @@ const OAuth2Options: FastifyOAuth2Options = {
     },
 };
 
-
 expectAssignable<FastifyOAuth2Options>({
     name: 'testOAuthName',
     scope: scope,
@@ -63,6 +62,26 @@ expectAssignable<FastifyOAuth2Options>({
     callbackUriParams: {},
     startRedirectPath: '/login/testOauth',
     pkce: 'S256'
+})
+
+expectAssignable<FastifyOAuth2Options>({
+    name: 'testOAuthName',
+    scope: scope,
+    credentials: credentials,
+    callbackUri: 'http://localhost/testOauth/callback',
+    callbackUriParams: {},
+    startRedirectPath: '/login/testOauth',
+    discovery: { issuer: 'https://idp.mycompany.com' }
+})
+
+expectNotAssignable<FastifyOAuth2Options>({
+    name: 'testOAuthName',
+    scope: scope,
+    credentials: credentials,
+    callbackUri: 'http://localhost/testOauth/callback',
+    callbackUriParams: {},
+    startRedirectPath: '/login/testOauth',
+    discovery: { issuer: 1 }
 })
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Closes #241

New option `discovery` is now available as described in #241.
Usage is very simple:
- add `discovery` object with `issuer` url in it
- remove `credentials.auth` to avoid confusion related to what is used, plugin will throw error down if both are used (since the intent is unclear)
- it will also select appropriate PKCE method based on metadata response when possible, 
(but if you want to force explicit method, you can still do it using top level option `pkce`)

Video shows how easy it is to switch from one issuer to another (I'm here switching from Google to Local OIDC provider, that has same client_id/client_secret pair :))


https://github.com/fastify/fastify-oauth2/assets/11753867/c36e464f-efea-49ef-b4fb-a90f63482270



#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
