### PR TITLE
Implements `userinfo` decorator to be used with `discovery` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,13 @@ fastify.googleOAuth2.revokeAllToken(currentAccessToken, undefined, (err) => {
 - `userinfo(tokenOrTokenSet)`: A function to retrieve userinfo data from Authorization Provider. Both token (as object) or `access_token` string value can be passed.
 
 Important note:
-Userinfo will only work when `discovery` option is used. For a statically configured plugin, you need to make a HTTP call yourself.
+Userinfo will only work when `discovery` option is used and such endpoint is advertised by identity provider. 
+
+For a statically configured plugin, you need to make a HTTP call yourself.
+
+See more on OIDC standard definition for [Userinfo endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo)
+
+See more on `userinfo_endpoint` property in [OIDC Discovery Metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata) standard definition.
 
 ```js
 fastify.googleOAuth2.userinfo(currentAccessToken, (err, userinfo) => {

--- a/README.md
+++ b/README.md
@@ -389,9 +389,11 @@ Custom parameters can be passed as option.
 See [Types](./types/index.d.ts) and usage patterns [in examples](./examples/userinfo.js).
 
 Note:
-(At the moment) We only support HTTP `GET` requests to userinfo endpoint sending access token in headers using `Bearer` schema.
-POST is not supported at the moment, but if your Server supports such case and you need it, feel free to [open an issue](https://github.com/fastify/fastify-oauth2/issues/new?assignees=&labels=feature+request&projects=&template=feature.yml).
 
+We support HTTP `GET` and `POST` requests to userinfo endpoint sending access token using `Bearer` schema in headers.
+You can do this by setting (`via: "header"` parameter), but it's not mandatory since it's a default value.
+
+We also support `POST` by sending `access_token` in a request body. You can do this by explicitly providing `via: "body"` parameter.
 
 E.g. For `name: 'customOauth2'`, the helpers `getAccessTokenFromAuthorizationCodeFlow` and `getNewAccessTokenUsingRefreshToken` will become accessible like this:
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Assuming we have registered multiple OAuth providers like this:
 
 ## Utilities
 
-This fastify plugin adds 5 utility decorators to your fastify instance using the same **namespace**:
+This fastify plugin adds 6 utility decorators to your fastify instance using the same **namespace**:
 
 - `getAccessTokenFromAuthorizationCodeFlow(request, callback)`: A function that uses the Authorization code flow to fetch an OAuth2 token using the data in the last request of the flow. If the callback is not passed it will return a promise. The callback call or promise resolution returns an [AccessToken](https://github.com/lelylan/simple-oauth2/blob/master/API.md#accesstoken) object, which has an `AccessToken.token` property with the following keys:
   - `access_token`
@@ -363,6 +363,36 @@ fastify.googleOAuth2.revokeAllToken(currentAccessToken, undefined, (err) => {
    // Handle the reply here
 });
 ```
+
+- `userinfo(tokenOrTokenSet)`: A function to retrieve userinfo data from Authorization Provider. Both token (as object) or `access_token` string value can be passed.
+
+Important note:
+Userinfo will only work when `discovery` option is used. For a statically configured plugin, you need to make a HTTP call yourself.
+
+```js
+fastify.googleOAuth2.userinfo(currentAccessToken, (err, userinfo) => {
+   // do something with userinfo
+});
+// with custom params
+fastify.googleOAuth2.userinfo(currentAccessToken, { method: 'GET', params: { /* add your custom key value pairs here to be appended to request */ } },  (err, userinfo) => {
+   // do something with userinfo
+});
+
+// or promise version
+const userinfo = await fastify.googleOAuth2.userinfo(currentAccessToken);
+// use custom params
+const userinfo = await fastify.googleOAuth2.userinfo(currentAccessToken, { method: 'GET', params: { /* ... */ } });
+```
+
+There are variants with callback and promises.
+Custom parameters can be passed as option.
+See [Types](./types/index.d.ts) and usage patterns [in examples](./examples/userinfo.js).
+
+Note:
+(At the moment) We only support HTTP `GET` requests to userinfo endpoint sending access token in headers using `Bearer` schema.
+POST is not supported at the moment, but if your Server supports such case and you need it, feel free to [open an issue](https://github.com/fastify/fastify-oauth2/issues/new?assignees=&labels=feature+request&projects=&template=feature.yml).
+
+
 E.g. For `name: 'customOauth2'`, the helpers `getAccessTokenFromAuthorizationCodeFlow` and `getNewAccessTokenUsingRefreshToken` will become accessible like this:
 
 - `fastify.oauth2CustomOauth2.getAccessTokenFromAuthorizationCodeFlow`

--- a/examples/userinfo.js
+++ b/examples/userinfo.js
@@ -1,0 +1,112 @@
+'use strict'
+
+const fastify = require('fastify')({ logger: { level: 'trace' } })
+
+const cookieOpts = {
+  path: '/',
+  secure: true,
+  sameSite: 'lax',
+  httpOnly: true
+}
+
+// const oauthPlugin = require('fastify-oauth2')
+const oauthPlugin = require('..')
+
+fastify.register(require('@fastify/cookie'), {
+  secret: ['my-secret'],
+  parseOptions: cookieOpts
+})
+
+fastify.register(oauthPlugin, {
+  name: 'googleOAuth2',
+  // when provided, this userAgent will also be used at discovery endpoint
+  // to fully omit for whatever reason, set it to false
+  userAgent: 'my custom app (v1.0.0)',
+  scope: ['openid', 'profile', 'email'],
+  credentials: {
+    client: {
+      id: process.env.CLIENT_ID,
+      secret: process.env.CLIENT_SECRET
+    }
+  },
+  startRedirectPath: '/login/google',
+  callbackUri: 'http://localhost:3000/interaction/callback/google',
+  cookie: cookieOpts,
+  discovery: {
+    issuer: 'https://accounts.google.com'
+  }
+})
+
+// using async/await (promises API) ->
+// 1. simple one with async
+fastify.get('/interaction/callback/google', async function (request, reply) {
+  try {
+    const tokenResponse = await this.googleOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, reply)
+    const userinfo = await this.googleOAuth2.userinfo(tokenResponse.token /* or tokenResponse.token.access_token */)
+    reply.send(userinfo)
+  } catch (error) {
+    // you want to handle error here better
+    console.error(error)
+    reply.send(error.message)
+  }
+})
+
+// 2. custom params one with async
+// fastify.get('/interaction/callback/google', { method: 'GET', params: { /* custom parameters to be added */ } }, async function (request, reply) {
+//   try {
+//     const tokenResponse = await this.googleOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, reply)
+//     const userinfo = await this.googleOAuth2.userinfo(tokenResponse.token /* or tokenResponse.token.access_token */)
+//     reply.send(userinfo)
+//   } catch (error) {
+//     // you want to handle error here better
+//     console.error(error)
+//     reply.send(error.message)
+//   }
+// })
+
+// OR with a callback API
+
+// 3. simple one with callback
+// fastify.get('/interaction/callback/google', function (request, reply) {
+//   const userInfoCallback = (err, userinfo) => {
+//     if (err) {
+//       reply.send(err)
+//       return
+//     }
+//     reply.send(userinfo)
+//   }
+
+//   const accessTokenCallback = (err, result) => {
+//     if (err) {
+//       reply.send(err)
+//       return
+//     }
+//     this.googleOAuth2.userinfo(result.token, userInfoCallback)
+//   }
+
+//   this.googleOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, reply, accessTokenCallback)
+// })
+
+// 4. custom params one with with callback
+// fastify.get('/interaction/callback/google', { method: 'GET', params: { /** custom parameters to be added */ } }, function (request, reply) {
+//   const userInfoCallback = (err, userinfo) => {
+//     if (err) {
+//       reply.send(err)
+//       return
+//     }
+//     reply.send(userinfo)
+//   }
+
+//   const accessTokenCallback = (err, result) => {
+//     if (err) {
+//       reply.send(err)
+//       return
+//     }
+//     this.googleOAuth2.userinfo(result.token, userInfoCallback)
+//   }
+
+//   this.googleOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, reply, accessTokenCallback)
+// })
+
+fastify.listen({ port: 3000 })
+fastify.log.info('go to http://localhost:3000/login/google')

--- a/examples/userinfo.js
+++ b/examples/userinfo.js
@@ -40,28 +40,16 @@ fastify.register(oauthPlugin, {
 // using async/await (promises API) ->
 // 1. simple one with async
 fastify.get('/interaction/callback/google', async function (request, reply) {
-  try {
-    const tokenResponse = await this.googleOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, reply)
-    const userinfo = await this.googleOAuth2.userinfo(tokenResponse.token /* or tokenResponse.token.access_token */)
-    reply.send(userinfo)
-  } catch (error) {
-    // you want to handle error here better
-    console.error(error)
-    reply.send(error.message)
-  }
+  const tokenResponse = await this.googleOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, reply)
+  const userinfo = await this.googleOAuth2.userinfo(tokenResponse.token /* or tokenResponse.token.access_token */)
+  return userinfo
 })
 
 // 2. custom params one with async
 // fastify.get('/interaction/callback/google', { method: 'GET', params: { /* custom parameters to be added */ } }, async function (request, reply) {
-//   try {
-//     const tokenResponse = await this.googleOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, reply)
-//     const userinfo = await this.googleOAuth2.userinfo(tokenResponse.token /* or tokenResponse.token.access_token */)
-//     reply.send(userinfo)
-//   } catch (error) {
-//     // you want to handle error here better
-//     console.error(error)
-//     reply.send(error.message)
-//   }
+//   const tokenResponse = await this.googleOAuth2.getAccessTokenFromAuthorizationCodeFlow(request, reply)
+//   const userinfo = await this.googleOAuth2.userinfo(tokenResponse.token /* or tokenResponse.token.access_token */)
+//   return userinfo
 // })
 
 // OR with a callback API

--- a/index.js
+++ b/index.js
@@ -475,10 +475,7 @@ function fastifyOauth2 (fastify, options, next) {
     const req = aClient.request(infoUrl, httpOpts, onUserinfoResponse)
       .on('error', errHandler)
 
-    if (via === 'body') {
-      req.write(body.toString())
-    }
-
+    req.write(body.toString())
     req.end()
 
     function onUserinfoResponse (res) {

--- a/index.js
+++ b/index.js
@@ -420,7 +420,7 @@ function fastifyOauth2 (fastify, options, next) {
   }
 
   function fetchUserInfo (userinfoEndpoint, token, { method, via, params }, cb) {
-    // here userinfo options { method, params } are ignored,
+    // here userinfo options { method, via } are ignored,
     // but it's useful to have a stable API for future when they are implemented/needed
 
     // Supported: a basic one, GET | token via headers | Accept json

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function fastifyOauth2 (fastify, options, next) {
     ? undefined
     : (options.userAgent || USER_AGENT)
 
-  const configure = (configured) => {
+  const configure = (configured, fetchedMetadata) => {
     const {
       name,
       callbackUri,
@@ -299,6 +299,40 @@ function fastifyOauth2 (fastify, options, next) {
       reply.clearCookie(VERIFIER_COOKIE_NAME, cookieOpts)
     }
 
+    const pUserInfo = promisify(userInfoCallbacked)
+
+    function userinfo (tokenSetOrToken, options, callback) {
+      const _callback = typeof options === 'function' ? options : callback
+      if (!_callback) {
+        return pUserInfo(tokenSetOrToken, options)
+      }
+      return userInfoCallbacked(tokenSetOrToken, options, _callback)
+    }
+
+    function userInfoCallbacked (tokenSetOrToken, { method = 'GET', via = 'header', params = {} } = {}, callback) {
+      if (!configured.discovery) {
+        callback(new Error('userinfo can not be used without discovery'))
+        return
+      }
+      let token
+      if (typeof tokenSetOrToken !== 'object' && typeof tokenSetOrToken !== 'string') {
+        callback(new Error('you should provide token object containing access_token or access_token as string directly'))
+        return
+      }
+
+      if (typeof tokenSetOrToken === 'object') {
+        if (typeof tokenSetOrToken.access_token !== 'string') {
+          callback(new Error('access_token should be string'))
+          return
+        }
+        token = tokenSetOrToken.access_token
+      } else {
+        token = tokenSetOrToken
+      }
+
+      fetchUserInfo(fetchedMetadata.userinfo_endpoint, token, { method, params, via }, callback)
+    }
+
     const oauth2 = new AuthorizationCode(configured.credentials)
 
     if (startRedirectPath) {
@@ -311,7 +345,8 @@ function fastifyOauth2 (fastify, options, next) {
       getNewAccessTokenUsingRefreshToken,
       generateAuthorizationUri,
       revokeToken,
-      revokeAllToken
+      revokeAllToken,
+      userinfo
     }
 
     try {
@@ -343,7 +378,7 @@ function fastifyOauth2 (fastify, options, next) {
         // otherwise select optimal pkce method for them,
         discoveredOptions.pkce = selectPkceFromMetadata(fetchedMetadata)
       }
-      configure(discoveredOptions)
+      configure(discoveredOptions, fetchedMetadata)
       next()
     })
   } else {
@@ -374,6 +409,56 @@ function fastifyOauth2 (fastify, options, next) {
     function onDiscoveryResponse (res) {
       let rawData = ''
       res.on('data', (chunk) => { rawData += chunk })
+      res.on('end', () => {
+        try {
+          cb(null, JSON.parse(rawData))
+        } catch (err) {
+          cb(err)
+        }
+      })
+    }
+  }
+
+  function fetchUserInfo (userinfoEndpoint, token, { method, via, params }, cb) {
+    // here userinfo options { method, params } are ignored,
+    // but it's useful to have a stable API for future when they are implemented/needed
+
+    // Supported: a basic one, GET | token via headers | Accept json
+
+    // not supported right now due to sheer number of combinations how body and header could be treated,
+    // but OIDC standard defines as possible also:
+    // POST -> via = headers
+    // POST -> via = body, then using Cont. Type (application/x-www-form-urlencoded)
+
+    const httpOpts = {
+      headers: {
+        ...options.credentials.http?.headers,
+        'User-Agent': userAgent,
+        Authorization: `Bearer ${token}`
+      }
+    }
+
+    if (omitUserAgent) {
+      delete httpOpts.headers['User-Agent']
+    }
+
+    const infoUrl = new URL(userinfoEndpoint)
+
+    Object.entries(params).forEach(([k, v]) => {
+      infoUrl.searchParams.append(k, v)
+    })
+
+    ;(userinfoEndpoint.startsWith('https://') ? https : http)
+      .get(userinfoEndpoint, httpOpts, onUserinfoResponse)
+      .on('error', (e) => {
+        const err = new Error('Problem calling userinfo endpoint. See innerError for details.')
+        err.innerError = e
+        cb(err)
+      })
+
+    function onUserinfoResponse (res) {
+      let rawData = ''
+      res.on('data', (chunk) => { rawData = chunk })
       res.on('end', () => {
         try {
           cb(null, JSON.parse(rawData))

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -171,19 +171,27 @@ declare namespace fastifyOauth2 {
             tokenType: TToken,
             httpOptions: Object | undefined,
             callback: (err: any) => void
-        ): void
+        ): void;
 
-        revokeToken(revokeToken: Token, tokenType: TToken, httpOptions: Object | undefined): Promise<void>
+        revokeToken(revokeToken: Token, tokenType: TToken, httpOptions: Object | undefined): Promise<void>;
 
         revokeAllToken(
             revokeToken: Token,
             httpOptions: Object | undefined,
             callback: (err: any) => void
         ): void;
+        
+        revokeAllToken(revokeToken: Token, httpOptions: Object | undefined): Promise<void>;
 
-        revokeAllToken(revokeToken: Token, httpOptions: Object | undefined): Promise<void>
+        userinfo(tokenSetOrToken: Token | string): Promise<Object>;
+
+        userinfo(tokenSetOrToken: Token | string, userInfoExtraOptions: UserInfoExtraOptions | undefined): Promise<Object>;
+
+        userinfo(tokenSetOrToken: Token | string, callback: (err: any, userinfo: Object) => void): void;
+
+        userinfo(tokenSetOrToken: Token | string, userInfoExtraOptions: UserInfoExtraOptions | undefined, callback: (err: any, userinfo: Object) => void): void;
     }
-
+    export type UserInfoExtraOptions = { method?: 'GET'/* | POST */, via?: 'header' /*| 'body'*/, params?: object };
     export const fastifyOauth2: FastifyOauth2
     export {fastifyOauth2 as default}
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -191,7 +191,7 @@ declare namespace fastifyOauth2 {
 
         userinfo(tokenSetOrToken: Token | string, userInfoExtraOptions: UserInfoExtraOptions | undefined, callback: (err: any, userinfo: Object) => void): void;
     }
-    export type UserInfoExtraOptions = { method?: 'GET'/* | POST */, via?: 'header' /*| 'body'*/, params?: object };
+    export type UserInfoExtraOptions = { method?: 'GET' | 'POST', via?: 'header' | 'body', params?: object };
     export const fastifyOauth2: FastifyOauth2
     export {fastifyOauth2 as default}
 }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -276,6 +276,9 @@ server.get('/testOauth/callback', async (request, reply) => {
     expectType<void>(server.testOAuthName.userinfo(token.token.access_token, () => {}));
     expectType<void>(server.testOAuthName.userinfo(token.token.access_token, undefined, () => {}));
     expectAssignable<UserInfoExtraOptions>({ method: 'GET', params: {}, via: 'header' });
+    expectAssignable<UserInfoExtraOptions>({ method: 'POST', params: { a: 1 }, via: 'header' });
+    expectAssignable<UserInfoExtraOptions>({ via: 'body' });
+    expectNotAssignable<UserInfoExtraOptions>({ via: 'donkey' });
     expectNotAssignable<UserInfoExtraOptions>({ something: 1 });
     // END userinfo tests
     

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -5,7 +5,8 @@ import fastifyOauth2, {
     Credentials,
     OAuth2Namespace,
     OAuth2Token,
-    ProviderConfiguration
+    ProviderConfiguration,
+    UserInfoExtraOptions
 } from '..';
 import type { ModuleOptions } from 'simple-oauth2';
 import { FastifyInstance } from 'fastify';
@@ -268,6 +269,17 @@ server.get('/testOauth/callback', async (request, reply) => {
 
     expectType<Promise<string>>(server.testOAuthName.generateAuthorizationUri(request, reply));
     expectType<void>(server.testOAuthName.generateAuthorizationUri(request, reply, (err) => {}))
+    // BEGIN userinfo tests
+    expectType<Promise<Object>>(server.testOAuthName.userinfo(token.token));
+    expectType<Promise<Object>>(server.testOAuthName.userinfo(token.token.access_token));
+    expectType<Object>(await server.testOAuthName.userinfo(token.token.access_token));
+    expectType<void>(server.testOAuthName.userinfo(token.token.access_token, () => {}));
+    expectType<void>(server.testOAuthName.userinfo(token.token.access_token, undefined, () => {}));
+    expectAssignable<UserInfoExtraOptions>({ method: 'GET', params: {}, via: 'header' });
+    expectNotAssignable<UserInfoExtraOptions>({ something: 1 });
+    // END userinfo tests
+    
+    expectType<string>(await server.testOAuthName.generateAuthorizationUri(request, reply));
     // error because missing reply argument
     expectError<string>(server.testOAuthName.generateAuthorizationUri(request));
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Implemented a 6th decorator to be used when Authorization Server metadata `discovery` feature is being used.
This helps users of the plugin to automate more.
By using `userinfo` decorator directly, instead of having to construct a call to `userinfo_endpoint` them selves (find, configure urls, provide env variables etc...), 
...they can have less cruft in code 🚂 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
