### PR TITLE
Add linkedin authentication example

### DIFF
--- a/examples/linkedin.js
+++ b/examples/linkedin.js
@@ -1,57 +1,57 @@
-"use strict";
+'use strict'
 
-const fastify = require("fastify")({ logger: { level: "trace" } });
-const sget = require("simple-get");
+const fastify = require('fastify')({ logger: { level: 'trace' } })
+const sget = require('simple-get')
 
 // const oauthPlugin = require('fastify-oauth2')
-const oauthPlugin = require("..");
+const oauthPlugin = require('..')
 
 fastify.register(oauthPlugin, {
-  name: "linkedinOAuth2",
-  scope: ["profile", "email", "openid"],
+  name: 'linkedinOAuth2',
+  scope: ['profile', 'email', 'openid'],
   credentials: {
     client: {
-      id: "<CLIENT_ID>",
-      secret: "<CLIENT_SECRET>",
+      id: '<CLIENT_ID>',
+      secret: '<CLIENT_SECRET>'
     },
-    auth: oauthPlugin.LINKEDIN_CONFIGURATION,
+    auth: oauthPlugin.LINKEDIN_CONFIGURATION
   },
   tokenRequestParams: {
-    client_id: "<CLIENT_ID>",
-    client_secret: "<CLIENT_SECRET>",
+    client_id: '<CLIENT_ID>',
+    client_secret: '<CLIENT_SECRET>'
   },
-  startRedirectPath: "/login/linkedin",
-  callbackUri: "http://localhost:3000/login/linkedin/callback",
-});
+  startRedirectPath: '/login/linkedin',
+  callbackUri: 'http://localhost:3000/login/linkedin/callback'
+})
 
-fastify.get("/login/linkedin/callback", function (request, reply) {
+fastify.get('/login/linkedin/callback', function (request, reply) {
   this.linkedinOAuth2.getAccessTokenFromAuthorizationCodeFlow(
     request,
     (err, result) => {
       if (err) {
-        reply.send(err);
-        return;
+        reply.send(err)
+        return
       }
 
       sget.concat(
         {
-          url: "https://api.linkedin.com/v2/userinfo",
-          method: "GET",
+          url: 'https://api.linkedin.com/v2/userinfo',
+          method: 'GET',
           headers: {
-            Authorization: "Bearer " + result.token.access_token,
+            Authorization: 'Bearer ' + result.token.access_token
           },
-          json: true,
+          json: true
         },
         function (err, res, data) {
           if (err) {
-            reply.send(err);
-            return;
+            reply.send(err)
+            return
           }
-          reply.send(data);
+          reply.send(data)
         }
-      );
+      )
     }
-  );
-});
+  )
+})
 
-fastify.listen({ port: 3000 });
+fastify.listen({ port: 3000 })

--- a/examples/linkedin.js
+++ b/examples/linkedin.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const fastify = require("fastify")({ logger: { level: "trace" } });
+const sget = require("simple-get");
+
+// const oauthPlugin = require('fastify-oauth2')
+const oauthPlugin = require("..");
+
+fastify.register(oauthPlugin, {
+  name: "linkedinOAuth2",
+  scope: ["profile", "email", "openid"],
+  credentials: {
+    client: {
+      id: "<CLIENT_ID>",
+      secret: "<CLIENT_SECRET>",
+    },
+    auth: oauthPlugin.LINKEDIN_CONFIGURATION,
+  },
+  tokenRequestParams: {
+    client_id: "<CLIENT_ID>",
+    client_secret: "<CLIENT_SECRET>",
+  },
+  startRedirectPath: "/login/linkedin",
+  callbackUri: "http://localhost:3000/login/linkedin/callback",
+});
+
+fastify.get("/login/linkedin/callback", function (request, reply) {
+  this.linkedinOAuth2.getAccessTokenFromAuthorizationCodeFlow(
+    request,
+    (err, result) => {
+      if (err) {
+        reply.send(err);
+        return;
+      }
+
+      sget.concat(
+        {
+          url: "https://api.linkedin.com/v2/userinfo",
+          method: "GET",
+          headers: {
+            Authorization: "Bearer " + result.token.access_token,
+          },
+          json: true,
+        },
+        function (err, res, data) {
+          if (err) {
+            reply.send(err);
+            return;
+          }
+          reply.send(data);
+        }
+      );
+    }
+  );
+});
+
+fastify.listen({ port: 3000 });


### PR DESCRIPTION
use tokenRequestParams to proceed with the correct flow with getAccessTokenFromAuthorizationCodeFlow

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
