### PR TITLE
fix: TypeError when omitting credentials.auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,9 @@ function fastifyOauth2 (fastify, options, next) {
   if (options.discovery && options.credentials.auth) {
     return next(new Error('when options.discovery.issuer is configured, credentials.auth should not be used'))
   }
+  if (!options.discovery && !options.credentials.auth) {
+    return next(new Error('options.discovery.issuer or credentials.auth have to be given'))
+  }
   if (!fastify.hasReplyDecorator('cookie')) {
     fastify.register(require('@fastify/cookie'))
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/oauth2",
-  "version": "7.8.1",
+  "version": "7.8.0",
   "description": "Perform login using oauth2 protocol",
   "main": "index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/oauth2",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "Perform login using oauth2 protocol",
   "main": "index.js",
   "type": "commonjs",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1878,6 +1878,26 @@ t.test('credentials.auth should not be provided when discovery is used', t => {
     })
 })
 
+t.test('not providing options.discovery.issuer and credentials.auth', t => {
+  t.plan(1)
+
+  const fastify = createFastify({ logger: { level: 'silent' } })
+
+  fastify.register(fastifyOauth2, {
+    name: 'the-name',
+    credentials: {
+      client: {
+        id: 'my-client-id',
+        secret: 'my-secret'
+      }
+    },
+    callbackUri: '/callback'
+  })
+    .ready(err => {
+      t.strictSame(err.message, 'options.discovery.issuer or credentials.auth have to be given')
+    })
+})
+
 t.test('options.schema', t => {
   const fastify = createFastify({ logger: { level: 'silent' }, exposeHeadRoutes: false })
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -107,7 +107,7 @@ declare namespace fastifyOauth2 {
             /** Parameter name used to send the client id. Default to client_id. */
             idParamName?: string | undefined;
         };
-        auth: ProviderConfiguration;
+        auth?: ProviderConfiguration;
         /**
          * Used to set global options to the internal http library (wreck).
          * All options except baseUrl are allowed

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -153,7 +153,7 @@ expectType<string[]>(tags);
 expectType<Credentials>(credentials);
 
 // Ensure duplicayed simple-oauth2 are compatible with simple-oauth2
-expectAssignable<ModuleOptions<string>>(credentials);
+//expectAssignable<ModuleOptions<string>>(credentials);
 expectAssignable<ModuleOptions["auth"]>(auth);
 // Ensure published types of simple-oauth2 are accepted
 expectAssignable<Credentials>(simpleOauth2Options);

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -153,7 +153,8 @@ expectType<string[]>(tags);
 expectType<Credentials>(credentials);
 
 // Ensure duplicayed simple-oauth2 are compatible with simple-oauth2
-//expectAssignable<ModuleOptions<string>>(credentials);
+const mockcredentials = {auth: {tokenHost: ''}, ...credentials };
+expectAssignable<ModuleOptions<string>>(mockcredentials);
 expectAssignable<ModuleOptions["auth"]>(auth);
 // Ensure published types of simple-oauth2 are accepted
 expectAssignable<Credentials>(simpleOauth2Options);

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -153,8 +153,7 @@ expectType<string[]>(tags);
 expectType<Credentials>(credentials);
 
 // Ensure duplicayed simple-oauth2 are compatible with simple-oauth2
-const mockcredentials = {auth: {tokenHost: ''}, ...credentials };
-expectAssignable<ModuleOptions<string>>(mockcredentials);
+expectAssignable<ModuleOptions<string>>({auth: {tokenHost: ''}, ...credentials });
 expectAssignable<ModuleOptions["auth"]>(auth);
 // Ensure published types of simple-oauth2 are accepted
 expectAssignable<Credentials>(simpleOauth2Options);


### PR DESCRIPTION
small fix patch to make `auth` optional, to allow using the `discovery.` option!

solves #246 #249 

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
