### PR TITLE
feat: generating callbackUri on fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ fastify.register(oauthPlugin, {
   startRedirectPath: '/login/facebook',
   // facebook redirect here after the user login
   callbackUri: 'http://localhost:3000/login/facebook/callback'
+  // You can also define callbackUri as a function that takes a FastifyRequest and returns a string
+  // callbackUri: req => `${req.protocol}://${req.hostname}/login/facebook/callback`,
 })
 
 fastify.get('/login/facebook/callback', async function (request, reply) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1399,7 +1399,7 @@ t.test('options.credentials should be an object', t => {
     })
 })
 
-t.test('options.callbackUri should be an object', t => {
+t.test('options.callbackUri should be a string or a function', t => {
   t.plan(1)
 
   const fastify = createFastify({ logger: { level: 'silent' } })
@@ -1415,7 +1415,7 @@ t.test('options.callbackUri should be an object', t => {
     }
   })
     .ready(err => {
-      t.strictSame(err.message, 'options.callbackUri should be a string')
+      t.strictSame(err.message, 'options.callbackUri should be a string or a function')
     })
 })
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,7 +34,7 @@ declare namespace fastifyOauth2 {
     name: string;
     scope?: string[];
     credentials: Credentials;
-    callbackUri: string;
+    callbackUri: string | ((req: FastifyRequest) => string);
     callbackUriParams?: Object;
     tokenRequestParams?: Object;
     generateStateFunction?: FastifyGenerateStateFunction;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -74,6 +74,16 @@ expectAssignable<FastifyOAuth2Options>({
     name: 'testOAuthName',
     scope: scope,
     credentials: credentials,
+    callbackUri: req => `${req.protocol}://${req.hostname}/callback`,
+    callbackUriParams: {},
+    startRedirectPath: '/login/testOauth',
+    pkce: 'S256'
+})
+
+expectAssignable<FastifyOAuth2Options>({
+    name: 'testOAuthName',
+    scope: scope,
+    credentials: credentials,
     callbackUri: 'http://localhost/testOauth/callback',
     callbackUriParams: {},
     startRedirectPath: '/login/testOauth',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Provides a simple solution for  https://github.com/fastify/fastify-oauth2/issues/254

The idea is that users of fastify-oauth2 can pass a `(req: FastifyRequest) => string`, i.e. a function that takes a FastifyRequest and returns a string, as `callbackUri` at plugin registration time. This is easy to use and should be sufficient for many use cases.

This PR does not implement support for generating  `callbackUriParams` on the fly. I suppose that can be handled in a separate PR if it is necessary. 

#### Checklist

- [X] run `npm run test`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
