### PR TITLE
feat: use generic on userinfo

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -183,13 +183,13 @@ declare namespace fastifyOauth2 {
         
         revokeAllToken(revokeToken: Token, httpOptions: Object | undefined): Promise<void>;
 
-        userinfo(tokenSetOrToken: Token | string): Promise<Object>;
+        userinfo<TUserInfo>(tokenSetOrToken: Token | string): Promise<TUserInfo>;
 
-        userinfo(tokenSetOrToken: Token | string, userInfoExtraOptions: UserInfoExtraOptions | undefined): Promise<Object>;
+        userinfo<TUserInfo>(tokenSetOrToken: Token | string, userInfoExtraOptions: UserInfoExtraOptions | undefined): Promise<TUserInfo>;
 
-        userinfo(tokenSetOrToken: Token | string, callback: (err: any, userinfo: Object) => void): void;
+        userinfo<TUserInfo>(tokenSetOrToken: Token | string, callback: (err: any, userinfo: TUserInfo) => void): void;
 
-        userinfo(tokenSetOrToken: Token | string, userInfoExtraOptions: UserInfoExtraOptions | undefined, callback: (err: any, userinfo: Object) => void): void;
+        userinfo<TUserInfo>(tokenSetOrToken: Token | string, userInfoExtraOptions: UserInfoExtraOptions | undefined, callback: (err: any, userinfo: TUserInfo) => void): void;
     }
     export type UserInfoExtraOptions = { method?: 'GET' | 'POST', via?: 'header' | 'body', params?: object };
     export const fastifyOauth2: FastifyOauth2


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
hi there, just adding to avoid an `as Type`, and generic is compatible with `Object` so it shouldn't break anything (as it already didn't)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
