### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
     "@types/simple-oauth2": "^5.0.7",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.12.0",
     "nock": "^13.5.4",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.