### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Wrapper around the [`simple-oauth2`](https://github.com/lelylan/simple-oauth2) library.
 
 v4.x of this module support Fastify v3.x
-[v3.x](https://github.com/fastify/fastify-oauth2/tree/3.x) of this module support Fastify v2.x
+v3.x of this module support Fastify v2.x
 
 ## Install
 


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71